### PR TITLE
feat(SelectInputLabelBox): Added new select input based on design requirements

### DIFF
--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.js
@@ -1,0 +1,110 @@
+
+import React from 'react';
+import styled from 'styled-components';
+
+import { checkDocumentEvent, openOptionsList, closeOptionsList, toggleOptionsList } from '../SelectInput';
+import SelectOptions from '../SelectInput/SelectOptions';
+import { colors } from '../styles/colors';
+import {typography} from '../styles/typography';
+
+const padding = '16px';
+
+export const Label = styled.div`
+  color: ${colors.black40};
+  transition: all 200ms;
+  transform: translateY(-50%);
+  position: absolute;
+  left: ${padding};
+  top: 50%;
+
+  ${props => props.value && `
+    top: 30%;
+    ${typography.caption}
+  `}
+`
+
+const Caret = styled.div`
+  position: absolute;
+  right: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    margin: auto;
+    border-left: 5px transparent solid;
+    border-right: 5px transparent solid;
+    border-${props => props.open ? 'bottom' : 'top'}: 5px ${props => props.open ? colors.black90 : colors.black40} solid;
+  }
+`;
+
+export const Value = styled.button`
+  border: 0;
+  background: transparent;
+  display: block;
+  width: 100%;
+  text-align: left;
+  ${typography.subhead1};
+  color: ${colors.black90};
+  height: 56px;
+  padding: 22px ${padding} 0 ${padding};
+  background: ${colors.black10};
+  box-sizing: border-box;
+  border-bottom: 2px solid ${colors.black40};
+  cursor: pointer;
+
+  &:focus {
+    outline: 0;
+    border-color: ${colors.green};
+  }
+`;
+
+export const Wrapper = styled.div`
+  position: relative;
+  cursor: pointer;
+  ${typography.subhead1};
+`;
+
+export default class SelectInputLabelBox extends React.Component {
+
+  constructor() {
+    super();
+    this.state = {
+      optionsListVisible: false
+    }
+  }
+
+  checkDocumentEvent = (e) => { checkDocumentEvent.call(this, e) }
+
+  openOptionsList = () => { openOptionsList.call(this) }
+
+  closeOptionsList = () => { closeOptionsList.call(this) }
+
+  toggleOptionsList = () => { toggleOptionsList.call(this) }
+
+  render() {
+    return (
+      <Wrapper onClick={this.toggleOptionsList}
+        {...this.props}
+        ref="clickEventElement">
+        <Caret open={this.state.optionsListVisible} />
+        <Label value={this.props.value}>{this.props.label}</Label>
+        <Value
+          open={this.state.optionsListVisible}
+          className="select-input-label-box-value"
+        >{this.props.value}</Value>
+        <SelectOptions
+          ref={(options) => { this.clickEventElement = options; }}
+          selectedOptions={this.props.value}
+          onOptionUpdate={this.props.onChange}
+          options={this.props.options}
+          visible={this.state.optionsListVisible}
+        />
+      </Wrapper>
+    )
+  }
+}

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.js
@@ -6,6 +6,7 @@ import { checkDocumentEvent, openOptionsList, closeOptionsList, toggleOptionsLis
 import SelectOptions from '../SelectInput/SelectOptions';
 import { colors } from '../styles/colors';
 import {typography} from '../styles/typography';
+import PropTypes from 'prop-types';
 
 const padding = '16px';
 
@@ -52,21 +53,26 @@ export const Value = styled.button`
   color: ${colors.black90};
   height: 56px;
   padding: 22px ${padding} 0 ${padding};
-  background: ${colors.black10};
+  background: ${colors.lighterGray};
   box-sizing: border-box;
-  border-bottom: 2px solid ${colors.black40};
-  cursor: pointer;
+  border-bottom: 2px solid ${props => props.isDisabled ? 'transparent' : colors.black40};
+  cursor: ${props => props.isDisabled ? 'auto' : 'pointer'};
 
   &:focus {
     outline: 0;
-    border-color: ${colors.green};
+    border-color: ${props => props.isDisabled ? 'transparent' : colors.green};
   }
 `;
 
+
+
 export const Wrapper = styled.div`
   position: relative;
-  cursor: pointer;
   ${typography.subhead1};
+
+  ${props => props.isDisabled && `
+    opacity: 0.6;
+  `}
 `;
 
 export default class SelectInputLabelBox extends React.Component {
@@ -95,6 +101,7 @@ export default class SelectInputLabelBox extends React.Component {
         <Label value={this.props.value}>{this.props.label}</Label>
         <Value
           open={this.state.optionsListVisible}
+          isDisabled={this.props.isDisabled}
           className="select-input-label-box-value"
         >{this.props.value}</Value>
         <SelectOptions
@@ -107,4 +114,21 @@ export default class SelectInputLabelBox extends React.Component {
       </Wrapper>
     )
   }
+}
+
+SelectInputLabelBox.defaultProps = {
+  value: '',
+  label: '',
+  isDisabled: false
+}
+
+SelectInputLabelBox.propTypes = {
+  value: PropTypes.any,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.any,
+    label: PropTypes.string,
+  })).isRequired,
+  onChange: PropTypes.func.isRequired,
+  label: PropTypes.string,
+  isDisabled: PropTypes.bool
 }

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.spec.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.spec.js
@@ -42,4 +42,14 @@ describe('SelectInputLabelBox', () => {
     wrapper.find('.select-input-label-box-value').simulate('click');
     expect(wrapper.state('optionsListVisible')).toBe(false)
   });
+
+  it('does not open when disabled', () => {
+    wrapper = mount(<SelectInputLabelBox
+      options={genericOptions}
+      onChange={changeSpy}
+      isDisabled
+    />)
+    wrapper.find('.select-input-label-box-value').simulate('click');
+    expect(wrapper.state('optionsListVisible')).toBe(false)
+  })
 });

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.spec.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SelectInputLabelBox from './SelectInputLabelBox';
+
+const genericOptions = [
+  { value: '1', label: 'Option One' },
+  { value: '2', label: 'Option Two' },
+  { value: '3', label: 'Option Three' },
+  { value: '4', label: 'Option Four' },
+  { value: '5', label: 'Option Five' },
+  { value: '6', label: 'Option Six' },
+  { value: '7', label: 'Option Seven' },
+  { value: '8', label: 'Option Eight' },
+  { value: '9', label: 'Option Nine' },
+  { value: '10', label: 'Option Ten' },
+  { value: '11', label: 'A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string' },
+];
+
+describe('SelectInputLabelBox', () => {
+  let changeSpy;
+  let wrapper;
+
+  beforeEach(() => {
+    changeSpy = jest.fn();
+    wrapper = mount(<SelectInputLabelBox
+      options={genericOptions}
+      onChange={changeSpy}
+    />)
+  })
+  
+  it('should output the new value when selected', () => {
+    wrapper.find('.pb-option').first().simulate('click');
+    expect(changeSpy).toHaveBeenCalledWith('1')
+    wrapper.find('.pb-option').last().simulate('click');
+    expect(changeSpy).toHaveBeenCalledWith('11')
+  });
+
+  it('should open and close the options list', () => {
+    wrapper.find('.select-input-label-box-value').simulate('click');
+    expect(wrapper.state('optionsListVisible')).toBe(true)
+    wrapper.find('.select-input-label-box-value').simulate('click');
+    expect(wrapper.state('optionsListVisible')).toBe(false)
+  });
+});

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { storiesOf, action } from '@storybook/react';
+import SelectInputLabelBox from './SelectInputLabelBox';
+
+
+const promotedOptions = [
+  { value: '101', label: 'Promoted Option 1', disabled: true },
+  { value: '102', label: 'Promoted Option 2' },
+];
+
+class WrapperComponent extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      value: ''
+    }
+  }
+  render = () => (
+    <SelectInputLabelBox
+      {...this.props}
+      value={this.state.value}
+      onChange={(value) => this.setState({value})}
+    />) 
+}
+
+const genericOptions = [
+  { value: '1', label: 'Option One' },
+  { value: '2', label: 'Option Two' },
+  { value: '3', label: 'Option Three' },
+  { value: '4', label: 'Option Four' },
+  { value: '5', label: 'Option Five' },
+  { value: '6', label: 'Option Six' },
+  { value: '7', label: 'Option Seven' },
+  { value: '8', label: 'Option Eight' },
+  { value: '9', label: 'Option Nine' },
+  { value: '10', label: 'Option Ten' },
+  { value: '11', label: 'A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string' },
+];
+
+const selectedOptions = [
+  '1',
+  '2',
+]
+
+storiesOf('Form', module)
+  .addWithChapters(
+  'SelectInputLabelBox',
+  {
+    info: `
+      Usage
+
+      ~~~
+      import React from 'react';
+      import {SelectInputLabelBox} from 'insidesales-components';
+      ~~~
+    `,
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'SelectInputLabelBox',
+            sectionFn: () => (
+              <div>
+                <SelectInputLabelBox
+                  label="Hello World!"
+                  onChange={action('Option Selected')}
+                  options={genericOptions} />
+              </div>
+            )
+          },
+          {
+            title: 'SelectInputLabelBox with Stateful wrapper',
+            sectionFn: () => (
+              <div>
+                <WrapperComponent
+                  label="Hello World!"
+                  options={genericOptions} />
+              </div>
+            )
+          },
+        ]
+      }
+    ]
+  }
+);
+

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
@@ -78,6 +78,29 @@ storiesOf('Form', module)
               </div>
             )
           },
+          {
+            title: 'Disabled SelectInputLabelBox',
+            sectionFn: () => (
+              <div>
+                <SelectInputLabelBox
+                  isDisabled={true}
+                  label="Hello World!"
+                  options={genericOptions} />
+              </div>
+            )
+          },
+          {
+            title: 'Disabled SelectInputLabelBox with value',
+            sectionFn: () => (
+              <div>
+                <SelectInputLabelBox
+                  isDisabled={true}
+                  label="Hello World!"
+                  value="Hi"
+                  options={genericOptions} />
+              </div>
+            )
+          },
         ]
       }
     ]

--- a/src/components/SelectInputLabelBox/index.js
+++ b/src/components/SelectInputLabelBox/index.js
@@ -1,0 +1,3 @@
+export {
+  default
+} from './SelectInputLabelBox';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,3 +17,4 @@ export {default as ToggleSlider} from './ToggleSlider';
 export {default as Icons} from './icons';
 export {default as RadioList} from './RadioList';
 export {default as Radio} from './RadioList/Radio';
+export {default as SelectInputLabelBox} from './SelectInputLabelBox';

--- a/src/components/styles/colors.js
+++ b/src/components/styles/colors.js
@@ -61,6 +61,7 @@ export const colors = {
   white74black: '#BDC9C9',
   offWhite: '#FEFEFE',
   hoverGray: '#D7DBDC',
+  lighterGray: '#F0F0F0',
   lightGray: '#D3DBDB',
   barLightGray: '#E1E1E1',
   barDarkGray: 'rgba(229,229,229,0.5)',


### PR DESCRIPTION
Added new select input based on design requirements which reuses code from SelectInput and SelectOptions


Closed:
![image](https://user-images.githubusercontent.com/16295814/37531805-d80d907e-2902-11e8-8ad7-77ed9b33fcb8.png)

Focus: 
![image](https://user-images.githubusercontent.com/16295814/37531777-c382258e-2902-11e8-90f2-730075e69ec4.png)

Open:
![image](https://user-images.githubusercontent.com/16295814/37531816-e21a6a92-2902-11e8-938b-73a52fd89657.png)

With value: 
![image](https://user-images.githubusercontent.com/16295814/37531873-18369ea2-2903-11e8-8666-c87ee4d5b2c5.png)



