### PR TITLE
Add Input Type to TextInput

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -326,8 +326,20 @@ class TextInput extends React.Component {
       : [];
   }
 
+  getInputType (inputType) {
+    switch(inputType) {
+      case 'password': {
+        return inputType;
+      }
+      default: {
+        return 'text';
+      }
+    }
+  }
+
   render() {
-    const { label, name, error, disabled, collapsed, className, options, promotedOptions, lowPadding, labelColor, lineColor } = this.props;
+    const { label, name, inputType, error, disabled, collapsed, className, options, promotedOptions, lowPadding, labelColor, lineColor } = this.props;
+
     return (
       <TextInputWrapper
         className={className}
@@ -344,7 +356,7 @@ class TextInput extends React.Component {
           lineColor={lineColor}
           collapsed={collapsed}>
           <InputItem
-            type='text'
+            type={this.getInputType(inputType)}
             onFocus={this.focused}
             onBlur={this.blurred}
             id={name}
@@ -389,6 +401,7 @@ TextInput.defaultProps = {
 TextInput.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  inputType: PropTypes.string,
   helper: PropTypes.string,
   error: PropTypes.string,
   disabled: PropTypes.bool,

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -247,6 +247,16 @@ storiesOf('Form', module)
                 </div>
               )
             },
+            {
+              title: 'Example: use inputType to change to password input',
+              sectionFn: () => (
+                <TextInput
+                  label="Password"
+                  name="password"
+                  inputType="password"
+                />
+              )
+            },
           ]
         }
       ]


### PR DESCRIPTION
TextInput now has a prop called `inputType` that allows a user to
specify 'password' or 'text' as the input type. More input types can be
added later as need arises.