### PR TITLE
feature(OverflowMenu): added openRight and icon props

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -42,7 +42,7 @@ const OptionsContainer = styled.div`
   position: absolute;
   top: ${props => props.openUp ? 'initial' : '31px'};
   bottom: ${props => props.openUp ? '31px' : 'initial'};
-  right: -6px;
+  right: ${props => props.openRight ? '-89px' : '-6px'};
 
   min-width: 120px;
   background-color: transparent;
@@ -52,7 +52,7 @@ const OptionsContainer = styled.div`
   &:before {
     position: absolute;
     content: '';
-    right: 10px;
+    right: ${props => props.openRight ? '94px' : '10px'};
     top: ${props => props.openUp ? 'auto' : '-5px'};
     bottom: ${props => props.openUp ? '-5px' : 'auto'};
     width: 14px;
@@ -65,7 +65,7 @@ const OptionsContainer = styled.div`
   &:after {
     position: absolute;
     content: '';
-    right: 10px;
+    right: ${props => props.openRight ? '94px' : '10px'};
     top: ${props => props.openUp ? 'auto' : '-16px'};
     bottom: ${props => props.openUp ? '-16px' : 'auto'};
     width: 0;
@@ -98,15 +98,23 @@ class OverflowMenu extends React.Component {
   static propTypes = {
     isDisabled: PropTypes.bool,
     openUp: PropTypes.bool,
+    openRight: PropTypes.bool,
     options: PropTypes.array.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    icon: PropTypes.element
   };
 
   static defaultProps = {
     isDisabled: false,
     openUp: false,
+    openRight: false,
     options: [],
-    onChange: value => value
+    onChange: value => value,
+    icon: <Icons.MoreVertIcon
+            className="overflow-menu__icon"
+            fill={colors.white80}
+            size={{ width: 24, height: 24 }}
+          />
   };
 
   constructor() {
@@ -161,14 +169,10 @@ class OverflowMenu extends React.Component {
       {...this.props}
       ref={(el) => { this.clickEventElement = el }}>
         <InteractiveElement onClick={() => { this.toggleMenu(); }}>
-          <Icons.MoreVertIcon
-            className="overflow-menu__icon"
-            fill={colors.white80}
-            size={{ width: 24, height: 24 }}
-          />
+          {this.props.icon}
         </InteractiveElement>
         {this.state.menuVisible &&
-          <OptionsContainer openUp={this.props.openUp}>
+          <OptionsContainer openUp={this.props.openUp} openRight={this.props.openRight}>
             <OptionsWrapper>
               {this.renderMenu()}
             </OptionsWrapper>

--- a/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -4,6 +4,8 @@ import { storiesOf, action } from '@storybook/react';
 
 import OverflowMenu from './';
 import { colors } from '../styles';
+import icons from '../icons';
+import AttachmentIcon from '../icons/AttachmentIcon';
 
 const DarkBackground = styled.div`
   padding: 10px;
@@ -54,6 +56,51 @@ storiesOf('Menus', module)
               ];
 
               return  <DarkBackground><OverflowMenu options={options} openUp /></DarkBackground>
+            }
+          },
+          {
+            title: 'Example: openRight',
+            sectionFn: () => {
+              const options = [
+                { action: action('click option'), label: 'Option 1' },
+                { action: action('click option'), label: 'Option 2' }
+              ];
+              const LeftDarkBackground = styled(DarkBackground)`
+                display: flex;
+                justify-content: flex-start;
+                align-items: flex-start;
+              `;
+
+              return  <LeftDarkBackground><OverflowMenu options={options} openRight /></LeftDarkBackground>
+            }
+          },
+          {
+            title: 'Example: openRight and openUp',
+            sectionFn: () => {
+              const options = [
+                { action: action('click option'), label: 'Option 1' },
+                { action: action('click option'), label: 'Option 2' }
+              ];
+              const LeftDarkBackground = styled(DarkBackground)`
+                display: flex;
+                justify-content: flex-start;
+                align-items: flex-start;
+              `;
+
+              return  <LeftDarkBackground><OverflowMenu options={options} openRight openUp /></LeftDarkBackground>
+            }
+          },
+          {
+            title: 'Example: custom icon',
+            sectionFn: () => {
+              const options = [
+                { action: action('click option'), label: 'Option 1' },
+                { action: action('click option'), label: 'Option 2' }
+              ];
+
+              const icon = <AttachmentIcon fill={colors.white80} size={{ width: 24, height: 24 }} />;
+
+              return  <DarkBackground><OverflowMenu options={options} icon={icon} /></DarkBackground>
             }
           }
         ]


### PR DESCRIPTION
# Open Right
<img width="1170" alt="screen shot 2018-06-12 at 5 30 14 pm" src="https://user-images.githubusercontent.com/6416887/41322513-8974a520-6e66-11e8-893e-15b23fe885de.png">

# Open Right and Up
<img width="1168" alt="screen shot 2018-06-12 at 5 30 34 pm" src="https://user-images.githubusercontent.com/6416887/41322515-898b8920-6e66-11e8-9ebb-6a9bf8f100a7.png">
<img width="1167" alt="screen shot 2018-06-12 at 5 30 43 pm" src="https://user-images.githubusercontent.com/6416887/41322538-b0f76452-6e66-11e8-9d3d-c06526582bd4.png">

# Custom Icon
<img width="1172" alt="screen shot 2018-06-12 at 5 31 06 pm" src="https://user-images.githubusercontent.com/6416887/41322517-89b71022-6e66-11e8-9f75-972851bdcc50.png">
