### PR TITLE
fix(OverflowMenu positioning): fixed styles to work with lengthy text

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -42,7 +42,8 @@ const OptionsContainer = styled.div`
   position: absolute;
   top: ${props => props.openUp ? 'initial' : '31px'};
   bottom: ${props => props.openUp ? '31px' : 'initial'};
-  right: ${props => props.openRight ? '-89px' : '-6px'};
+  right: ${props => props.openRight ? 'auto' : '-6px'};
+  left: ${props => props.openRight ? '-6px' : 'auto'};
 
   min-width: 120px;
   background-color: transparent;
@@ -52,7 +53,8 @@ const OptionsContainer = styled.div`
   &:before {
     position: absolute;
     content: '';
-    right: ${props => props.openRight ? '94px' : '10px'};
+    right: ${props => props.openRight ? 'auto' : '10px'};
+    left: ${props => props.openRight ? '10px' : 'auto'};
     top: ${props => props.openUp ? 'auto' : '-5px'};
     bottom: ${props => props.openUp ? '-5px' : 'auto'};
     width: 14px;
@@ -65,7 +67,8 @@ const OptionsContainer = styled.div`
   &:after {
     position: absolute;
     content: '';
-    right: ${props => props.openRight ? '94px' : '10px'};
+    right: ${props => props.openRight ? 'auto' : '10px'};
+    left: ${props => props.openRight ? '10px' : 'auto'};
     top: ${props => props.openUp ? 'auto' : '-16px'};
     bottom: ${props => props.openUp ? '-16px' : 'auto'};
     width: 0;

--- a/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -78,8 +78,8 @@ storiesOf('Menus', module)
             title: 'Example: openRight and openUp',
             sectionFn: () => {
               const options = [
-                { action: action('click option'), label: 'Option 1' },
-                { action: action('click option'), label: 'Option 2' }
+                { action: action('click option'), label: 'This is some really, length text for demo' },
+                { action: action('click option'), label: 'Some short text' }
               ];
               const LeftDarkBackground = styled(DarkBackground)`
                 display: flex;


### PR DESCRIPTION
<img width="614" alt="screen shot 2018-06-13 at 12 55 41 pm" src="https://user-images.githubusercontent.com/6416887/41371940-1c7d98e8-6f09-11e8-83a7-90a4e438de12.png">
