### PR TITLE
Add disabled styling to toggle slider

### DIFF
--- a/src/components/ToggleSlider/ToggleSlider.js
+++ b/src/components/ToggleSlider/ToggleSlider.js
@@ -18,6 +18,9 @@ const SliderInput = styled.input`
 
 const SliderTrack = styled.div`
   background-color: ${(props) => {
+    if (props.disabled) {
+      return colors.darkGray;
+    }
     if (props.checked) {
       return colors.green70;
     }
@@ -34,6 +37,10 @@ const SliderTrack = styled.div`
 
   &:before {
     background-color: ${(props) => {
+      debugger;
+      if (props.disabled) {
+        return colors.darkslategray;
+      }
       if (props.checked) {
         return colors.green;
       }
@@ -48,7 +55,7 @@ const SliderTrack = styled.div`
     position: absolute;
     top: -3px;
     transform: ${(props) => {
-      if (props.checked) {
+      if (props.checked && !props.disabled) {
         return 'translateX(17px)';
       }
 
@@ -65,9 +72,10 @@ class ToggleSlider extends React.PureComponent {
       <SliderBase>
         <SliderInput
           type="checkbox"
+          disabled={this.props.disabled}
           onChange={this.props.toggle}
           checked={this.props.checked} />
-        <SliderTrack checked={this.props.checked} />
+        <SliderTrack checked={this.props.checked} disabled={this.props.disabled} />
       </SliderBase>
     );
   }
@@ -77,11 +85,13 @@ ToggleSlider.defaultProps = {
   /** Function to execute when toggle is clicked */
   toggle: () => {},
   /** Boolean of whether the toggle is on */
-  checked: false
+  checked: false,
+  disabled: false
 };
 
 ToggleSlider.propTypes = {
   checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired
 };
 

--- a/src/components/ToggleSlider/ToggleSlider.js
+++ b/src/components/ToggleSlider/ToggleSlider.js
@@ -19,7 +19,7 @@ const SliderInput = styled.input`
 const SliderTrack = styled.div`
   background-color: ${(props) => {
     if (props.disabled) {
-      return colors.darkGray;
+      return colors.grayD;
     }
     if (props.checked) {
       return colors.green70;
@@ -39,7 +39,7 @@ const SliderTrack = styled.div`
     background-color: ${(props) => {
       debugger;
       if (props.disabled) {
-        return colors.darkslategray;
+        return colors.grayC;
       }
       if (props.checked) {
         return colors.green;

--- a/src/components/ToggleSlider/ToggleSlider.js
+++ b/src/components/ToggleSlider/ToggleSlider.js
@@ -37,7 +37,6 @@ const SliderTrack = styled.div`
 
   &:before {
     background-color: ${(props) => {
-      debugger;
       if (props.disabled) {
         return colors.grayC;
       }

--- a/src/components/ToggleSlider/ToggleSlider.spec.js
+++ b/src/components/ToggleSlider/ToggleSlider.spec.js
@@ -15,15 +15,20 @@ describe('ToggleSlider', () => {
       expect(onToggle).toHaveBeenCalled();
     }, 0)
   });
+  it('toggle')
 });
 
 describe('ToggleSlider Snapshots', () => {
   test('shows toggled on', () => {
-    const tree = renderer.create(<ToggleSlider checked={true} toggle={_.noop} />);
+    const tree = renderer.create(<ToggleSlider checked={true} disabled={false} toggle={_.noop} />);
     expect(tree).toMatchSnapshot();
   })
   test('shows toggled off', () => {
-    const tree = renderer.create(<ToggleSlider checked={false} toggle={_.noop}/>);
+    const tree = renderer.create(<ToggleSlider checked={false} disabled={false} toggle={_.noop}/>);
+    expect(tree).toMatchSnapshot();
+  });
+  test('shows disabled', () => {
+    const tree = renderer.create(<ToggleSlider checked={false} disabled={true} toggle={_.noop}/>);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/components/ToggleSlider/ToggleSlider.stories.js
+++ b/src/components/ToggleSlider/ToggleSlider.stories.js
@@ -7,13 +7,14 @@ class ToggleSliderWrapper extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      checked: true
+      checked: props.checked,
+      disabled: props.disabled
     };
   }
   render() {
-    return <ToggleSlider checked={this.state.checked} toggle={() => {
+    return <ToggleSlider checked={this.state.checked} disabled={this.state.disabled} toggle={() => {
       this.props.toggle();
-      this.setState({ checked: !this.state.checked })
+      this.setState({ checked: !this.state.checked})
     }
     } />
   }
@@ -54,10 +55,21 @@ storiesOf('Form', module)
             )
           },
           {
+            title: 'Example: Disabled Toggle',
+            subtitle: 'A toggle slider that cannot be toggled.',
+            sectionFn: () => (
+              <ToggleSliderWrapper toggle={action("toggled")}
+              checked={false}
+              disabled={true} />
+            )
+          },
+          {
             title: 'Example: Wrapped in another component',
             subtitle: 'A toggle slider wrapped by another component that updates the checked prop on toggle',
             sectionFn: () => (
-              <ToggleSliderWrapper toggle={action("toggled")} />
+              <ToggleSliderWrapper toggle={action("toggled")}
+              checked={true}
+              disabled={false} />
             )
           }
         ]

--- a/src/components/ToggleSlider/__snapshots__/ToggleSlider.spec.js.snap
+++ b/src/components/ToggleSlider/__snapshots__/ToggleSlider.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ToggleSlider Snapshots shows disabled 1`] = `
+<label
+  className="sc-bdVaJa equNwL"
+>
+  <input
+    checked={false}
+    className="sc-bwzfXH eKeXgs"
+    disabled={true}
+    onChange={[Function]}
+    type="checkbox"
+  />
+  <div
+    checked={false}
+    className="sc-htpNat jiIFKi"
+    disabled={true}
+  />
+</label>
+`;
+
 exports[`ToggleSlider Snapshots shows toggled off 1`] = `
 <label
   className="sc-bdVaJa equNwL"
@@ -7,12 +26,14 @@ exports[`ToggleSlider Snapshots shows toggled off 1`] = `
   <input
     checked={false}
     className="sc-bwzfXH eKeXgs"
+    disabled={false}
     onChange={[Function]}
     type="checkbox"
   />
   <div
     checked={false}
     className="sc-htpNat dwgooG"
+    disabled={false}
   />
 </label>
 `;
@@ -24,12 +45,14 @@ exports[`ToggleSlider Snapshots shows toggled on 1`] = `
   <input
     checked={true}
     className="sc-bwzfXH eKeXgs"
+    disabled={false}
     onChange={[Function]}
     type="checkbox"
   />
   <div
     checked={true}
     className="sc-htpNat dFyors"
+    disabled={false}
   />
 </label>
 `;

--- a/src/components/ToggleSlider/__snapshots__/ToggleSlider.spec.js.snap
+++ b/src/components/ToggleSlider/__snapshots__/ToggleSlider.spec.js.snap
@@ -13,7 +13,7 @@ exports[`ToggleSlider Snapshots shows disabled 1`] = `
   />
   <div
     checked={false}
-    className="sc-htpNat jiIFKi"
+    className="sc-htpNat iYUQYI"
     disabled={true}
   />
 </label>


### PR DESCRIPTION
Added styling to render disabled ToggleSliders darker than the unchecked ToggleSlider. Will be used in Playbooks settings for User CRM Sync settings.

Relevant InVision: https://insidesales.invisionapp.com/share/CHJ95OQ9QMN#/screens/302082905