### PR TITLE
feat(TextInputBox): allow the box to be stateless

### DIFF
--- a/src/components/TextInputBox/TextInputBox.js
+++ b/src/components/TextInputBox/TextInputBox.js
@@ -94,7 +94,7 @@ export default class TextInputBox extends TextInput {
                     onClick={this.focusOnTextInput}
                     isFocused={this.state.focused}
                     error={error}
-                    open={this.state.value}
+                    open={this.getValue()}
                     disabled={disabled}
                     lineColor={lineColor}
                     collapsed={collapsed}
@@ -107,14 +107,14 @@ export default class TextInputBox extends TextInput {
                     name={name}
                     disabled={disabled}
                     error={error}
-                    value={this.state.value}
+                    value={this.getValue()}
                     ref={(input) => { this.textInputEl = ReactDOM.findDOMNode(input); }}
                     onChange={this.onChange} />
                 { this.props.label &&
                     <TextBoxLabel 
                         isFocused={this.state.focused} 
                         labelColor={this.props.theme.labelColor || labelColor} 
-                        open={this.state.value} 
+                        open={this.getValue()} 
                         htmlFor={name} 
                         error={error}>{label}
                     </TextBoxLabel>

--- a/src/components/TextInputBox/TextInputBox.stories.js
+++ b/src/components/TextInputBox/TextInputBox.stories.js
@@ -89,6 +89,28 @@ storiesOf('Form', module)
                 />
               )
             },
+            {
+              title: 'Example: Stateless',
+              sectionFn: () => (
+                <TextInputBox
+                  label="This is a test"
+                  value="I am stateless"
+                  onChange={action('value')}
+                  stateless
+                />
+              )
+            },
+            {
+              title: 'Example: Stateless no value',
+              sectionFn: () => (
+                <TextInputBox
+                  label="This is a test"
+                  value=""
+                  onChange={action('value')}
+                  stateless
+                />
+              )
+            },
           ]
         }
       ]

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -32,7 +32,7 @@ export {default as Radio} from './RadioList/Radio';
 export {
   default as SelectInputLabelBox,
   darkTheme as SelectInputLabelBoxDarkTheme,
-  ineSelectInputBoxTransparentTheme as SelectInputLabelBoxlineSelectInputBoxTransparentTheme
+  lineSelectInputBoxTransparentTheme as SelectInputLabelBoxLineSelectInputBoxTransparentTheme
 } from './SelectInputLabelBox';
 export {default as TextareaBox} from './TextareaBox';
 export { colors, boxShadows, scrollbars, typography } from './styles'


### PR DESCRIPTION
Fixed a typo in the themes export. 
Changed a few lines to let the TextInputBox component be stateless.