### PR TITLE
fix(SelectInputLabelBox): On multiselect allow options list to remain open when clicked

### DIFF
--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.js
@@ -239,13 +239,14 @@ export default class SelectInputLabelBox extends React.Component {
 
     return (
       <ThemeProvider theme={this.props.theme}>
-        <Wrapper onClick={this.toggleOptionsList}
+        <Wrapper
           {...this.props}
           ref={(el) => { this.clickEventElement = el }}
           >
           <Caret open={this.state.optionsListVisible} />
           <Label value={this.props.value}>{this.props.label}</Label>
           <Value
+            onClick={this.toggleOptionsList}
             open={this.state.optionsListVisible}
             isDisabled={this.props.isDisabled}
             title={optionLabel}


### PR DESCRIPTION
Changed where the options list was being toggled to be more in line with the SelectInput component. (Code and structure from that component is used in this one)