### PR TITLE
fix(SelectInputLabelBox, TextInputBox): allow custom option width and…

### DIFF
--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.js
@@ -258,6 +258,7 @@ export default class SelectInputLabelBox extends React.Component {
             promotedOptions={promotedOptions}
             onOptionUpdate={this.onChange}
             options={options}
+            width={this.props.optionsWidth}
             hideDivider={_.isEmpty(this.props.options)}
             visible={this.state.optionsListVisible}
             multiSelect={this.props.multiSelect}

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
@@ -167,6 +167,18 @@ storiesOf('Form', module)
             )
           },
           {
+            title: 'SelectInputLabelBox with custom options width',
+            sectionFn: () => (
+              <div>
+                <SelectInputLabelBox
+                  label="Hello World!"
+                  optionsWidth="240"
+                  onChange={action('Option Selected')}
+                  options={genericOptions} />
+              </div>
+            )
+          },
+          {
             title: 'Disabled SelectInputLabelBox',
             sectionFn: () => (
               <div>

--- a/src/components/TextInputBox/TextInputBox.js
+++ b/src/components/TextInputBox/TextInputBox.js
@@ -39,7 +39,7 @@ const TextBox = styled.div`
     width: 100%;
     padding-left: 16px;
     padding-right: 16px;
-    padding-bottom: ${props => props.label ? '10px' : '18px'};
+    padding-bottom: ${props => props.label ? '9px' : '17px'};
 
     ${(props) => {
         if (props.disabled) {


### PR DESCRIPTION
… fix height diff on text input

Change to padding was to make sure all "box" inputs were 56px tall. TextInput used to be 57px tall and when they're next to each other it looked bad.