### PR TITLE
feat(TextInput(Box)): allow errors with boolean values

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -250,7 +250,7 @@ class TextInput extends React.Component {
   renderHelperText = () => {
     const { error, helper, collapsed } = this.props;
 
-    if(!error && !helper) {
+    if((!error || _.isBoolean(error)) && !helper) {
       return null;
     }
 
@@ -450,7 +450,7 @@ TextInput.propTypes = {
   label: PropTypes.string.isRequired,
   inputType: PropTypes.string,
   helper: PropTypes.string,
-  error: PropTypes.string,
+  error: PropTypes.any,
   disabled: PropTypes.bool,
   value: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/components/TextInputBox/TextInputBox.js
+++ b/src/components/TextInputBox/TextInputBox.js
@@ -138,7 +138,7 @@ TextInput.propTypes = {
     name: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     inputType: PropTypes.string,
-    error: PropTypes.string,
+    error: PropTypes.any,
     disabled: PropTypes.bool,
     value: PropTypes.any,
     onChange: PropTypes.func,

--- a/src/components/TextInputBox/TextInputBox.stories.js
+++ b/src/components/TextInputBox/TextInputBox.stories.js
@@ -5,7 +5,9 @@ import {
 } from '@storybook/react';
 
 import TextInputBox from './TextInputBox';
-import { darkTheme } from './TextInputBoxThemes';
+import TextInputBoxThemes, { darkTheme } from './TextInputBoxThemes';
+
+import { colors } from "../styles/colors";
 
 
 storiesOf('Form', module)
@@ -130,6 +132,35 @@ storiesOf('Form', module)
                   onChange={action('value')}
                   stateless
                 />
+              )
+            },
+            {
+              title: 'Example: helper',
+              sectionFn: () => (
+                <TextInputBox
+                  label="This is a test"
+                  value={false}
+                  onChange={action('value')}
+                  stateless
+                  helper="Help me Obi-Wan Kenobi"
+                />
+              )
+            },
+            {
+              title: 'Example: dark theme with error',
+              sectionFn: () => (
+                <div style={{
+                  background: colors.black40,
+                  padding: '15px',
+                }}>
+                  <TextInputBox
+                    label="This is a test"
+                    theme={TextInputBoxThemes.darkTheme}
+                    value="error"
+                    onChange={action('value')}
+                    error
+                  />
+                </div>
               )
             },
           ]


### PR DESCRIPTION
Allows boolean values as a valid error prop type, makes sure that boolean errors don't take up extra room when rendering.