### PR TITLE
fix(Thumbnail): added default color to box

### DIFF
--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { boxShadows, colors } from '../styles';
 
 const Box = styled.div`
+    color: ${colors.black80};
     position: absolute;
     border-radius: 4px;
     background: white;


### PR DESCRIPTION
This fixes the issue that the thumbnail box was inheriting white text. Being that it's in a white box, the white text was difficult to read (understatement).