### PR TITLE
feat(MessageDialog): Allow dialogs with no actions

### DIFF
--- a/src/components/MessageDialog/MessageDialog.js
+++ b/src/components/MessageDialog/MessageDialog.js
@@ -46,6 +46,8 @@ class MessageDialog extends React.Component {
       center,
       ...props
     } = this.props;
+    const canRenderButtonBar = props.primaryActionText || props.secondaryActionText;
+
     return (
         <Modal {...props}>
           <ContentWrapper>
@@ -56,7 +58,9 @@ class MessageDialog extends React.Component {
               {bodyElement}
             </BodyDisplay>
           </ContentWrapper>
-          <ButtonBar {...this.props} />
+          {canRenderButtonBar &&
+            <ButtonBar {...this.props} />
+          }
         </Modal>
     );
   }

--- a/src/components/MessageDialog/MessageDialog.stories.js
+++ b/src/components/MessageDialog/MessageDialog.stories.js
@@ -41,6 +41,21 @@ storiesOf('Components', module)
                 />
               )
             },
+            {
+              title: 'Modal with no actions',
+              sectionFn: () => (
+                <MessageDialog
+                  dialogTitle="Syncing from Salesforce"
+                  bodyElement={
+                    <p>
+                      Syncing information from Salesforce may take a few seconds...
+                    </p>
+                  }
+                  center
+                  onStoryBook
+                />
+              )
+            }
           ]
         }
       ]


### PR DESCRIPTION
Sometimes the app will show and remove dialogs by some other logic than user interaction. Allow Message Dialogs to have no button bar