### PR TITLE
fix(TextInput): adjust border-radius on TextInput 

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -52,7 +52,12 @@ export const TextBox = styled.div`
   border: ${(props) => {
     return props.outlinedSearch ? "1px solid rgba(0,0,0,0.4)" : 'none'
   }};
-  border-radius: 3px;
+  border-radius: ${(props) => {
+    if (props.disabled) {
+      return '3px';
+    }
+    return '0';
+  }};
   background-color: ${colors.white};
   border-bottom: thin solid ${colors.black40};
   border-color: ${(props) => {
@@ -68,7 +73,7 @@ export const TextBox = styled.div`
     return colors.black40;
   }};
   border-width: ${(props) => {
-    if (props.isFocused || props.error) {
+    if (props.isFocused || props.error || props.disabled) {
       return '2px';
     }
     return '1px';
@@ -93,17 +98,8 @@ export const TextBox = styled.div`
   width: 100%;
 
   &:hover {
-    border-width: ${(props) => {
-      if (props.disabled) {
-        return '1px';
-      }
-      return '2px';
-    }};
-    padding-bottom: ${(props) => {
-      if (props.disabled) {
-        return '8px';
-      }
-      return '7px';
+    border-width: 2px;
+    padding-bottom: 7px;
     }};
   }
 


### PR DESCRIPTION
**I removed the border radius on TextInput unless the component is in disabled state.**
Partially addresses https://github.com/InsideSalesOfficial/insidesales-components/issues/226.

### Examples:
Before:
<img width="62" alt="Screen Shot 2019-03-27 at 11 40 20 AM" src="https://user-images.githubusercontent.com/18040782/55099425-44673e00-5085-11e9-90a4-d80d89bd5b12.png">
After:
<img width="73" alt="Screen Shot 2019-03-27 at 11 37 51 AM" src="https://user-images.githubusercontent.com/18040782/55099461-534df080-5085-11e9-8678-f06d7a359c7a.png">

Before:
<img width="72" alt="Screen Shot 2019-03-27 at 11 40 35 AM" src="https://user-images.githubusercontent.com/18040782/55099557-82fcf880-5085-11e9-8d88-f940f7b7d9f4.png">
After:
<img width="80" alt="Screen Shot 2019-03-27 at 11 37 26 AM" src="https://user-images.githubusercontent.com/18040782/55099570-898b7000-5085-11e9-8b97-31f51d63082d.png">

Before:
<img width="89" alt="Screen Shot 2019-03-27 at 11 39 55 AM" src="https://user-images.githubusercontent.com/18040782/55099602-98722280-5085-11e9-900b-05629002c1a4.png">
After:
<img width="96" alt="Screen Shot 2019-03-27 at 11 37 17 AM" src="https://user-images.githubusercontent.com/18040782/55099624-a162f400-5085-11e9-9d61-19c9f1cad463.png">


