### PR TITLE
fix(OverflowMenu): fix border-radius and add larger size options

### DIFF
--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -21,7 +21,12 @@ const SelectOption = styled.div`
 
   box-sizing: border-box;
   display: flex;
-  padding: 0 10px;
+  padding: 0 10px 0 ${(props) => {
+    if (props.medium || props.large) {
+      return 24;
+    }
+    return 10;
+  }}px;
   width: 100%;
   height: 38px;
   transition: background .25s ease-in-out;
@@ -78,8 +83,15 @@ const OptionsContainer = styled.div`
   bottom: ${props => props.openUp ? `calc(100% + ${caretSize}px)` : 'initial'};
   right: ${props => props.openRight ? 'auto' : '-6px'};
   left: ${props => props.openRight ? '-6px' : 'auto'};
-
-  min-width: 120px;
+  ${(props) => {
+    if (props.medium) {
+      return 'width: 160px;';
+    }
+    if (props.large) {
+      return 'width: 200px;';
+    }
+    return 'min-width: 120px;';
+  }}
   background-color: transparent;
   overflow: visible;
   z-index: 1;
@@ -89,12 +101,13 @@ const OptionsWrapper = styled.div`
   width: 100%;
   align-items: flex-start;
   background-color: ${colors.white};
-  border-radius: 2px;
+  border-radius: 3px;
   box-shadow: ${boxShadows.lvl20};
 `;
 
 const SubmenuOptionsWrapper = styled.div`
   display: flex;
+  border-radius: 3px;
   background-color: ${colors.white};
 
   &:first-child ${SelectOption} {
@@ -121,7 +134,9 @@ class OverflowMenu extends React.Component {
     options: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     icon: PropTypes.element,
-    stayOpen: PropTypes.bool
+    stayOpen: PropTypes.bool,
+    medium: PropTypes.bool,
+    large: PropTypes.bool
   };
 
   static defaultProps = {
@@ -135,7 +150,9 @@ class OverflowMenu extends React.Component {
       fill={colors.white80}
       size={{ width: 24, height: 24 }}
     />,
-    stayOpen: false
+    stayOpen: false,
+    medium: false,
+    large: false
   };
 
   constructor() {
@@ -199,7 +216,8 @@ class OverflowMenu extends React.Component {
         onMouseEnter={this.handleSelectedId(option.id, depthLevel)}
         onClick={option.isDisabled ? ()=> {} : option.action}
         isHighlighted={option.isHighlighted}
-        isDisabled={option.isDisabled}>{option.label}</SelectOption>
+        isDisabled={option.isDisabled}
+        {...this.props}>{option.label}</SelectOption>
 
       let submenu;
       if (this.state.selectedIds[depthLevel] === option.id && _.get(option,'subOptions.length',0) > 0) {
@@ -207,8 +225,8 @@ class OverflowMenu extends React.Component {
         submenu = this.renderMenu(option.subOptions, newDepthLevel);
       }
       return (
-        <SubmenuOptionsWrapper>
-          <OptionsWrapper >
+        <SubmenuOptionsWrapper key={idx}>
+          <OptionsWrapper>
             {mainMenu}
           </OptionsWrapper>
           {!_.isUndefined(submenu) &&
@@ -238,7 +256,9 @@ class OverflowMenu extends React.Component {
           </FlexInteractiveElement>
           {(this.state.menuVisible || this.props.stayOpen) &&
               [<DropdownCaret {..._.pick(this.props, ['openUp', 'openDown'])} />,
-              <OptionsContainer openUp={this.props.openUp} openRight={this.props.openRight}>
+              <OptionsContainer openUp={this.props.openUp} openRight={this.props.openRight}
+                medium={this.props.medium} large={this.props.large}
+              >
                 {this.renderMenu(this.props.options)}
               </OptionsContainer>]
           }

--- a/src/components/OverflowMenu/OverflowMenu.js
+++ b/src/components/OverflowMenu/OverflowMenu.js
@@ -21,12 +21,7 @@ const SelectOption = styled.div`
 
   box-sizing: border-box;
   display: flex;
-  padding: 0 10px 0 ${(props) => {
-    if (props.medium || props.large) {
-      return 24;
-    }
-    return 10;
-  }}px;
+  padding: 0 24px 0 10px;
   width: 100%;
   height: 38px;
   transition: background .25s ease-in-out;
@@ -83,15 +78,7 @@ const OptionsContainer = styled.div`
   bottom: ${props => props.openUp ? `calc(100% + ${caretSize}px)` : 'initial'};
   right: ${props => props.openRight ? 'auto' : '-6px'};
   left: ${props => props.openRight ? '-6px' : 'auto'};
-  ${(props) => {
-    if (props.medium) {
-      return 'width: 160px;';
-    }
-    if (props.large) {
-      return 'width: 200px;';
-    }
-    return 'min-width: 120px;';
-  }}
+  min-width: 120px;
   background-color: transparent;
   overflow: visible;
   z-index: 1;
@@ -134,9 +121,7 @@ class OverflowMenu extends React.Component {
     options: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     icon: PropTypes.element,
-    stayOpen: PropTypes.bool,
-    medium: PropTypes.bool,
-    large: PropTypes.bool
+    stayOpen: PropTypes.bool
   };
 
   static defaultProps = {
@@ -150,9 +135,7 @@ class OverflowMenu extends React.Component {
       fill={colors.white80}
       size={{ width: 24, height: 24 }}
     />,
-    stayOpen: false,
-    medium: false,
-    large: false
+    stayOpen: false
   };
 
   constructor() {
@@ -216,8 +199,7 @@ class OverflowMenu extends React.Component {
         onMouseEnter={this.handleSelectedId(option.id, depthLevel)}
         onClick={option.isDisabled ? ()=> {} : option.action}
         isHighlighted={option.isHighlighted}
-        isDisabled={option.isDisabled}
-        {...this.props}>{option.label}</SelectOption>
+        isDisabled={option.isDisabled}>{option.label}</SelectOption>
 
       let submenu;
       if (this.state.selectedIds[depthLevel] === option.id && _.get(option,'subOptions.length',0) > 0) {
@@ -256,9 +238,7 @@ class OverflowMenu extends React.Component {
           </FlexInteractiveElement>
           {(this.state.menuVisible || this.props.stayOpen) &&
               [<DropdownCaret {..._.pick(this.props, ['openUp', 'openDown'])} />,
-              <OptionsContainer openUp={this.props.openUp} openRight={this.props.openRight}
-                medium={this.props.medium} large={this.props.large}
-              >
+              <OptionsContainer openUp={this.props.openUp} openRight={this.props.openRight}>
                 {this.renderMenu(this.props.options)}
               </OptionsContainer>]
           }

--- a/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -125,7 +125,29 @@ storiesOf('Menus', module)
 
                 return <DarkBackground><OverflowMenu options={options}/></DarkBackground>
               }
-            }
+            },
+            {
+              title: 'Example: medium menu size',
+              sectionFn: () => {
+                const options = [
+                  { action: action('click option'), label: 'Medium' },
+                  { action: action('click option'), label: 'Option 2' },
+                ];
+
+                return  <DarkBackground><OverflowMenu options={options} medium/></DarkBackground>
+              }
+            },
+            {
+              title: 'Example: large menu size',
+              sectionFn: () => {
+                const options = [
+                  { action: action('click option'), label: 'Large' },
+                  { action: action('click option'), label: 'Option 2' },
+                ];
+
+                return  <DarkBackground><OverflowMenu options={options} large/></DarkBackground>
+              }
+            },
           ]
         }
       ]

--- a/src/components/OverflowMenu/OverflowMenu.stories.js
+++ b/src/components/OverflowMenu/OverflowMenu.stories.js
@@ -126,28 +126,6 @@ storiesOf('Menus', module)
                 return <DarkBackground><OverflowMenu options={options}/></DarkBackground>
               }
             },
-            {
-              title: 'Example: medium menu size',
-              sectionFn: () => {
-                const options = [
-                  { action: action('click option'), label: 'Medium' },
-                  { action: action('click option'), label: 'Option 2' },
-                ];
-
-                return  <DarkBackground><OverflowMenu options={options} medium/></DarkBackground>
-              }
-            },
-            {
-              title: 'Example: large menu size',
-              sectionFn: () => {
-                const options = [
-                  { action: action('click option'), label: 'Large' },
-                  { action: action('click option'), label: 'Option 2' },
-                ];
-
-                return  <DarkBackground><OverflowMenu options={options} large/></DarkBackground>
-              }
-            },
           ]
         }
       ]


### PR DESCRIPTION
This addresses https://github.com/InsideSalesOfficial/insidesales-components/issues/225

**Changes:**
* fix corners not being rounded
* adjust border-radius to 3px by request from Kellie
* add medium and large props for larger menu options
* add key to SubmenuOptionsWrapper component

**before:**
<img width="222" alt="Screen Shot 2019-03-27 at 5 23 42 PM" src="https://user-images.githubusercontent.com/18040782/55118833-52cd4e00-50b5-11e9-930d-d19028ed630f.png">

**after:**
default
<img width="224" alt="Screen Shot 2019-03-27 at 5 10 48 PM" src="https://user-images.githubusercontent.com/18040782/55118841-5b258900-50b5-11e9-8c56-c18eb84cfc39.png">
medium
<img width="223" alt="Screen Shot 2019-03-27 at 5 11 17 PM" src="https://user-images.githubusercontent.com/18040782/55118848-5f51a680-50b5-11e9-8ba4-66c4ff26eed8.png">
large
<img width="223" alt="Screen Shot 2019-03-27 at 5 11 44 PM" src="https://user-images.githubusercontent.com/18040782/55118858-64aef100-50b5-11e9-9ae5-a064dad6d93b.png">
