### PR TITLE
Set label white-space to nowrap

### DIFF
--- a/src/components/StepChain/StepChain.js
+++ b/src/components/StepChain/StepChain.js
@@ -72,6 +72,7 @@ const StyledCheckMark = styled(Icons.CheckmarkFilledIcon)`
 const StepName = styled.div`
   text-align: center;
   color: ${renderThemeIfPresentOrDefault({ key: 'white40', defaultValue: colors.black40 })};
+  white-space: nowrap;
   ${typography.body2}
 `;
 

--- a/src/components/StepChain/StepChain.stories.js
+++ b/src/components/StepChain/StepChain.stories.js
@@ -35,7 +35,7 @@ function renderChapterWithTheme(theme) {
               sectionFn: () => (
                 <ThemeComponent theme={theme}>
                   <StepChain
-                    stepLabels={['Name', 'Connect', 'Record']}
+                    stepLabels={['Sign In', 'Connect', 'Record']}
                     currentStep={1}
                   />
                 </ThemeComponent>
@@ -46,7 +46,7 @@ function renderChapterWithTheme(theme) {
               sectionFn: () => (
                 <ThemeComponent theme={theme}>
                   <StepChain
-                    stepLabels={['Name', 'Connect', 'Record']}
+                    stepLabels={['Sign In', 'Connect', 'Record']}
                     currentStep={2}
                   />
                 </ThemeComponent>
@@ -57,7 +57,7 @@ function renderChapterWithTheme(theme) {
               sectionFn: () => (
                 <ThemeComponent theme={theme}>
                   <StepChain
-                    stepLabels={['Name', 'Connect', 'Record']}
+                    stepLabels={['Sign In', 'Connect', 'Record']}
                     currentStep={3}
                   />
                 </ThemeComponent>


### PR DESCRIPTION
Every word was wrapping after the last change:
<img width="345" alt="Screen Shot 2020-01-17 at 1 36 54 PM" src="https://user-images.githubusercontent.com/1188980/72644725-fdf21100-392e-11ea-8bb3-da5aa34818d7.png">

With `white-space: nowrap`:
<img width="345" alt="Screen Shot 2020-01-17 at 1 37 13 PM" src="https://user-images.githubusercontent.com/1188980/72644724-fdf21100-392e-11ea-82c5-5330bb1db56a.png">
