### PR TITLE
fix(Chain): Set Chain label white-space to nowrap

### DIFF
--- a/src/components/StepChain/StepChain.js
+++ b/src/components/StepChain/StepChain.js
@@ -3,80 +3,63 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import _ from 'lodash';
 
-import {
-  colors,
-  typography,
-  renderThemeIfPresentOrDefault,
-} from '../styles';
+import { colors, typography, renderThemeIfPresentOrDefault } from '../styles';
 import Icons from '../icons';
 
 const StepChainWrapper = styled.div`
   position: relative;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr 32px 1fr);
 `;
 
-const Line = styled.div`
-  width: 100%;
-  align-self: flex-start;
-  padding-top: 20px;
-  border-bottom: 2px solid ${renderThemeIfPresentOrDefault({ key: 'white60', defaultValue: colors.black20 })};
-`;
-
-const StepWrapper = styled.div`
-  position: relative;
-  width: 40px;
+const Number = styled.div`
   display: flex;
-  flex-direction: column;
+  justify-self: center;
   align-items: center;
-`;
-
-const StepItem = styled.div`
-  position: relative;
+  justify-content: center;
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  color: ${renderThemeIfPresentOrDefault({ key: 'white60', defaultValue: colors.white })};
-  background-color: ${renderThemeIfPresentOrDefault({ key: 'white10', defaultValue: colors.aluminum })};
-  margin: 8px;
-  box-sizing: content-box;
-`;
-
-const ColoredStep = styled(StepItem)`
-  color: ${renderThemeIfPresentOrDefault({ key: 'primary03', defaultValue: colors.white })};
-  background-color: ${renderThemeIfPresentOrDefault({ key: 'brand01', defaultValue: colors.green })};
-`;
-
-const StepText = styled.span`
-  position: absolute;
-  display: inline-block;
-  top: 0;
-  bottom: 0;
-  height: fit-content;
-  margin: auto;
-  width: 100%;
-  text-align: center;
+  color: ${props =>
+    props.colorChange
+      ? renderThemeIfPresentOrDefault({ key: 'white60', defaultValue: colors.white })
+      : renderThemeIfPresentOrDefault({ key: 'primary03', defaultValue: colors.white })};
+  background-color: ${props =>
+    props.colorChange
+      ? renderThemeIfPresentOrDefault({ key: 'white10', defaultValue: colors.aluminum })
+      : renderThemeIfPresentOrDefault({ key: 'brand01', defaultValue: colors.green })};
+  grid-column: ${props => props.column};
   ${typography.caption}
 `;
 
-const StyledCheckMark = styled(Icons.CheckmarkFilledIcon)`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  margin: auto;
-  fill: ${renderThemeIfPresentOrDefault({ key: 'primary03', defaultValue: colors.white })};
-`;
-
-const StepName = styled.div`
+const Label = styled.div`
   text-align: center;
-  color: ${renderThemeIfPresentOrDefault({ key: 'white40', defaultValue: colors.black40 })};
+  grid-row: 2;
+  grid-column-start: ${props => props.column - 1};
+  grid-column-end: ${props => props.column + 2};
+  color: ${props =>
+    props.colorChange
+      ? renderThemeIfPresentOrDefault({ key: 'white40', defaultValue: colors.black40 })
+      : renderThemeIfPresentOrDefault({ key: 'white90', defaultValue: colors.black90 })};
   ${typography.body2}
 `;
 
-const DarkStepName = styled(StepName)`
-  color: ${renderThemeIfPresentOrDefault({ key: 'white90', defaultValue: colors.black90 })};
+const Line = styled.div`
+  :first-child {
+    border-top: none;
+  }
+  :last-child {
+    border-top: none;
+  }
+  width: 100%;
+  align-self: center;
+  border-top: 2px solid
+    ${renderThemeIfPresentOrDefault({ key: 'white60', defaultValue: colors.black20 })};
+  grid-column: ${props => props.column};
+`;
+
+const StyledCheckMark = styled(Icons.CheckmarkFilledIcon)`
+  fill: ${renderThemeIfPresentOrDefault({ key: 'primary03', defaultValue: colors.white })};
 `;
 
 class StepChain extends React.Component {
@@ -84,60 +67,47 @@ class StepChain extends React.Component {
     super(props);
 
     this.state = {
-      focused: false
+      focused: false,
     };
   }
 
-  checkMark = () => (<StyledCheckMark size={{width: '20px', height: '20px'}} />);
+  checkMark = () => <StyledCheckMark size={{ width: '20px', height: '20px' }} />;
 
   chainItems = () => {
     const { stepLabels, currentStep } = this.props;
-    return stepLabels.reduce((array, text, key) => {
-      const keyPlus = key + 1;
-      const step = () => {
-        if (currentStep >= keyPlus) {
-        const checkOrKey = (currentStep === keyPlus) ? keyPlus : this.checkMark();
-        return (
-          <StepWrapper key={key}>
-            <ColoredStep>
-              <StepText>{checkOrKey}</StepText>
-            </ColoredStep>
-            <DarkStepName>{text}</DarkStepName>
-          </StepWrapper>
-        );
-      }
-      return (
-        <StepWrapper key={key}>
-          <StepItem>
-            <StepText>{keyPlus}</StepText>
-          </StepItem>
-          <StepName>{text}</StepName>
-        </StepWrapper>
+    return stepLabels.reduce((array, label, index) => {
+      const col = index * 3 + 2;
+      const checkOrKey = currentStep <= index + 1 ? index + 1 : this.checkMark();
+      const colorChange = currentStep <= index;
+      array.push(
+        <Line column={col - 1} />,
+        <Number column={col} colorChange={colorChange}>
+          {checkOrKey}
+        </Number>,
+        <Label column={col} colorChange={colorChange}>
+          {label}
+        </Label>,
+        <Line column={col + 1} />
       );
-    }
-    array.push(step());
-    stepLabels.length - 1 !== key && array.push(<Line />);
-    return array
-  }, [])
+      return array;
+    }, []);
   };
 
   render() {
     return (
-      <StepChainWrapper className={this.props.className}>
-        {this.chainItems()}
-      </StepChainWrapper>
+      <StepChainWrapper className={this.props.className}>{this.chainItems()}</StepChainWrapper>
     );
   }
 }
 
 StepChain.defaultProps = {
-  stepLabels: ['a','b'],
-  currentStep: 1
+  stepLabels: ['a', 'b'],
+  currentStep: 1,
 };
 
 StepChain.propTypes = {
   stepLabels: PropTypes.array.isRequired,
-  currentStep: PropTypes.number.isRequired
+  currentStep: PropTypes.number.isRequired,
 };
 
 export default StepChain;

--- a/src/components/StepChain/StepChain.stories.js
+++ b/src/components/StepChain/StepChain.stories.js
@@ -11,7 +11,7 @@ import { generateFlexedThemeBackground } from '../styles/index.js';
 
 const ThemeComponent = (props) => (
   <ThemeProvider theme={props.theme}>
-    <div style={generateFlexedThemeBackground(props, { width: '300px', padding: '24px' })}>
+    <div style={generateFlexedThemeBackground(props, { width: '100%', padding: '24px 0' })}>
       {props.children}
     </div>
   </ThemeProvider>
@@ -35,7 +35,7 @@ function renderChapterWithTheme(theme) {
               sectionFn: () => (
                 <ThemeComponent theme={theme}>
                   <StepChain
-                    stepLabels={['Name', 'Connect', 'Record']}
+                    stepLabels={['Sign In', 'Connect', 'Record']}
                     currentStep={1}
                   />
                 </ThemeComponent>
@@ -46,7 +46,7 @@ function renderChapterWithTheme(theme) {
               sectionFn: () => (
                 <ThemeComponent theme={theme}>
                   <StepChain
-                    stepLabels={['Name', 'Connect', 'Record']}
+                    stepLabels={['Sign In', 'Connect', 'Record']}
                     currentStep={2}
                   />
                 </ThemeComponent>
@@ -57,7 +57,7 @@ function renderChapterWithTheme(theme) {
               sectionFn: () => (
                 <ThemeComponent theme={theme}>
                   <StepChain
-                    stepLabels={['Name', 'Connect', 'Record']}
+                    stepLabels={['Sign In', 'Connect', 'Record']}
                     currentStep={3}
                   />
                 </ThemeComponent>


### PR DESCRIPTION
In order to fix the text formatting issues, this uses CSS grid.

The text labels span three columns on the second row. Above, there's a columns for lines and numbers.
<img width="1215" alt="Screen Shot 2020-01-21 at 4 47 29 PM" src="https://user-images.githubusercontent.com/1188980/72853319-4a5e8900-3c6e-11ea-8f49-b5d2fa42e699.png">

This splits the labels into equally sized sections, wrapping as needed based on the available space:
<img width="1073" alt="Screen Shot 2020-01-21 at 4 46 53 PM" src="https://user-images.githubusercontent.com/1188980/72853321-4a5e8900-3c6e-11ea-933c-10df85b53f5f.png">
<img width="432" alt="Screen Shot 2020-01-21 at 4 47 05 PM" src="https://user-images.githubusercontent.com/1188980/72853320-4a5e8900-3c6e-11ea-8b1f-baf4e66595da.png">

