### PR TITLE
fix(Radio): Enable keyboard input for radio buttons

### DIFF
--- a/src/components/RadioList/Radio.js
+++ b/src/components/RadioList/Radio.js
@@ -36,11 +36,11 @@ const RadioLabel = styled.label`
       return `6px ${props.theme.padding} 4px ${props.theme.padding}`;
     } else if (!_.isEmpty(props.theme.padding)) {
       return props.theme.padding;
-    } 
+    }
     return '0.75em';
   }};
   margin: ${props => props.theme.margin} 0;
-  
+
   ${props => {
     if (props.active) {
       return css`
@@ -61,7 +61,9 @@ const RadioLabel = styled.label`
 `;
 
 const RadioInput = styled.input`
-  display: none;
+  opacity: 0;
+  position: fixed;
+  width: 0;
 `;
 
 function renderThemedRadioCircleBorder(props) {
@@ -107,7 +109,7 @@ const RadioCircle = styled.span`
       left: 50%;
       transform: translate(-50%, -50%);
     }
-  `} 
+  `}
 `;
 
 const MultiLineLabelWrapper = styled.div`
@@ -149,6 +151,7 @@ const RadioComponent = ({ id, name, label = "", value, setValue, selectedValue =
       value={value}
       checked={active}
       onChange={() => { setValue(value) }}
+      onFocus={() => { setValue(value) }}
     />
     <RadioLabel htmlFor={id} active={active} label={label}>
       <RadioCircle active={active}></RadioCircle>{findLabel(label)}

--- a/src/components/RadioList/RadioList.stories.js
+++ b/src/components/RadioList/RadioList.stories.js
@@ -9,7 +9,6 @@ import { colors } from "../styles/colors.js";
 import { generateFlexedThemeBackground } from "../styles/index.js";
 
 let value = 3;
-let name = "test-radio";
 
 function wrapComponentWithContainerAndTheme(theme, Component) {
   const storyContainerStyle = generateFlexedThemeBackground(
@@ -65,7 +64,7 @@ function renderChapterWithTheme(theme) {
                   radios={radios}
                   value={value}
                   onChange={action("onChange")}
-                  name={name}
+                  name={"standard-radio-list"}
                 />
               );
             }
@@ -100,7 +99,7 @@ function renderChapterWithTheme(theme) {
                   value={value}
                   theme={lightRadioListTheme}
                   onChange={action("onChange")}
-                  name={name}
+                  name={"light-themed-radio-list"}
                 />
               );
             }
@@ -131,7 +130,7 @@ function renderChapterWithTheme(theme) {
                   super();
 
                   this.state = {
-                    value: 1
+                    value: null
                   };
                 }
 
@@ -145,7 +144,7 @@ function renderChapterWithTheme(theme) {
                         onChange={val => {
                           this.setState({ value: val });
                         }}
-                        name={name}
+                        name={"stateful-wrapper"}
                       />
 
                       <div>Current Value: {this.state.value}</div>
@@ -200,7 +199,7 @@ function renderChapterWithTheme(theme) {
                   radios={radios}
                   value={value}
                   onChange={action("onChange")}
-                  name={name}
+                  name={"two-line-label"}
                 />
               );
             }


### PR DESCRIPTION
![radio-keyboard_001](https://user-images.githubusercontent.com/1188980/84288345-4b4d6580-aafe-11ea-8254-aba08d2e7ad0.gif)

- Use opacity instead of display to hide the buttons, which allows access
to the buttons in the dom for keyboard and accessibility use.
- Normally, when tabbing to a radio list, the first input is focused. Pressing
down after this causes the second option to be selected, which looks wrong when we don't have the normal focus styled because of our custom radio buttons. Instead,
this autoselects a value when it is focused, causing the first value
to be selected upon tabbing into a radio list.
- Fix the names of different radio list sets in storybook. The name
attribute must be set correctly when this component is used to get
the correct tabindex order.


