### PR TITLE
fix(SelectInput): Fix SelectInput option menu alignment

### DIFF
--- a/src/components/SelectInput/SelectInput.js
+++ b/src/components/SelectInput/SelectInput.js
@@ -30,7 +30,7 @@ const StyledCloseIcon = styled(CloseIcon)`
 const SelectBaseWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: flex-end;
   justify-content: ${(props) => {
     if (props.theme.wrapperJustifyContent) {
       return props.theme.wrapperJustifyContent;


### PR DESCRIPTION
Some CSS that was added recently to SelectInput needed an alignment tweak.
<img width="1663" alt="Screen Shot 2020-07-23 at 11 23 24 AM" src="https://user-images.githubusercontent.com/1188980/88320605-0e6ab600-ccdb-11ea-8fef-516acf40a647.png">
