### PR TITLE
feat(SelectInputKeyboard): Add select input with keyboard support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 120,
+  "semi": true,
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always",
+  "parser": "babel",
+  "htmlWhitespaceSensitivity": "strict"
+}

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -60,6 +60,9 @@ const ButtonBase = styled.button`
   background: var(--background);
 
   transition: box-shadow .25s ease-in-out, background-color .25s ease-in-out;
+  &:focus {
+    box-shadow: 0 0 0 1px ${props => renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: colors.green10})};
+  }
   &:hover {
     background-color: ${(props) => {
       if (props.flat || props.flatAlt || props.outline) {
@@ -108,7 +111,7 @@ const ButtonBase = styled.button`
       }
     }};
   }
-  
+
   &:disabled {
     box-shadow: ${(props) => {
       if (props.flat || props.flatAlt || props.outline) {
@@ -175,7 +178,6 @@ const ButtonBase = styled.button`
 
   height: 36px;
   line-height: 24px;
-  outline: 0;
 
   width: auto;
   min-width: 88px;
@@ -216,6 +218,7 @@ export const Button = withTheme(({ className, label, loading, onClick, ...props 
     className={className ? [buttonSelector, className].join(' ') : buttonSelector}
     onClick={() => { if (!loading && !props.fade && onClick) { debouncedOnClick(); } }}
     loading={loading}
+    tabIndex={props.disabled ? -1 : 0}
     {...props}
   >
     <span>

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -75,7 +75,7 @@ const Text = styled.label`
   ${typography.subhead1}
 `;
 
-const Checkbox = ({ label, defaultChecked, checked, disabled, name, onChange, className, theme, greenDisabled }) => (
+const Checkbox = ({ label, defaultChecked, checked, disabled, name, onChange, className, theme, greenDisabled, tabIndex }) => (
   <ThemeProvider theme={theme}>
     <div className={className}>
       <CheckboxEl
@@ -88,6 +88,7 @@ const Checkbox = ({ label, defaultChecked, checked, disabled, name, onChange, cl
         checked={checked}
         disabled={disabled}
         className="pb-test__checkbox"
+        tabIndex={tabIndex}
         onClick={ onChange } />
       {label && (
         <Text htmlFor={name}>{label}</Text>
@@ -104,14 +105,16 @@ Checkbox.propTypes = {
   name: PropTypes.name,
   onChange: PropTypes.func,
   className: PropTypes.string,
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  tabIndex: PropTypes.number
 };
 
 Checkbox.defaultProps = {
   defaultChecked: false,
   disabled: false,
   onChange: _.noop,
-  theme: defaultTheme
+  theme: defaultTheme,
+  tabIndex: 0
 };
 
 export default Checkbox;

--- a/src/components/RequiredText/RequiredText.js
+++ b/src/components/RequiredText/RequiredText.js
@@ -1,11 +1,13 @@
 import {colors} from '../styles/colors';
 import {typography} from '../styles/typography';
 import styled from 'styled-components';
+import { renderThemeKeyOrDefaultValue } from "../styles";
 
 export const RequiredText = styled.div`
   color: ${(props) => {
-    return props.theme.requiredColor || colors.black40;
-}};
+    if (props.error) return renderThemeKeyOrDefaultValue({ props, key: 'warning04', defaultValue: colors.red });
+    return renderThemeKeyOrDefaultValue({ props, key: 'white90', defaultValue: colors.black40 });
+  }}
   opacity: ${(props) => {
   if (props.open || props.isFocused) {
     return 0;

--- a/src/components/SelectInputKeyboard/Caret.js
+++ b/src/components/SelectInputKeyboard/Caret.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { renderThemeKeyOrDefaultValue, colors } from '../styles';
+
+const caretStyles = `
+position: absolute;
+right: 24px;
+top: 50%;
+transform: translateY(-50%);
+cursor: pointer;
+
+&::after {
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 0;
+  margin: auto;
+  border-left: 5px transparent solid;
+  border-right: 5px transparent solid;
+}
+`;
+
+const CaretDown = styled.div`
+  ${caretStyles}
+  &::after {
+    border-top: 5px
+      ${(props) => {
+        if (props.isDisabled)
+          return renderThemeKeyOrDefaultValue({ props, key: 'white10', defaultValue: colors.white10 });
+        if (props.error) return renderThemeKeyOrDefaultValue({ props, key: 'warning', defaultValue: colors.red });
+        return renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: props.theme.borderColor });
+      }}
+      solid;
+  }
+`;
+
+const CaretUp = styled.div`
+  ${caretStyles}
+  &::after {
+    border-bottom: 5px
+      ${(props) => {
+        if (props.error) return renderThemeKeyOrDefaultValue({ props, key: 'warning', defaultValue: colors.red });
+        return renderThemeKeyOrDefaultValue({ props, key: 'white60', defaultValue: props.theme.borderColor });
+      }}
+      solid;
+  }
+`;
+
+function Caret({ error, isDisabled, isOpen }) {
+  return isOpen ? <CaretUp error={error} /> : <CaretDown error={error} isDisabled={isDisabled} />;
+}
+
+Caret.propTypes = {
+  error: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  isOpen: PropTypes.bool.isRequired,
+};
+
+export default Caret;

--- a/src/components/SelectInputKeyboard/Dropdown.js
+++ b/src/components/SelectInputKeyboard/Dropdown.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { keyframes } from 'styled-components';
+import { renderThemeKeyOrDefaultValue, renderThemeIfPresentOrDefault, colors, boxShadows } from '../styles';
+import Option from './Option';
+import Search from './Search';
+import _ from 'lodash';
+
+const fadeIn = keyframes`
+  0% {
+    transform: scaleY(0.9);
+    opacity: 0;
+  }
+  15% { opacity: 1; }
+  40% { transform: scaleY(1); }
+`;
+
+const Options = styled.ul`
+  max-width: ${(props) => (props.optionsWidth ? `${props.optionsWidth}px` : '100%')};
+  background: ${(props) =>
+    renderThemeKeyOrDefaultValue({ props, key: 'primary05', defaultValue: props.theme.background })};
+  display: ${(props) => (props.isOpen ? 'block' : 'none')};
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+  max-height: 240px;
+  margin: 0;
+  padding: 0;
+  transform: translateZ(0);
+  overflow-y: auto;
+  li:first-child {
+    margin-top: 8px;
+  }
+  li:last-child {
+    margin-bottom: 8px;
+  }
+
+  &::-webkit-scrollbar {
+    background-color: ${renderThemeIfPresentOrDefault({ key: 'primary05', defaultValue: colors.white })};
+    border-left: none;
+    margin-right: 10px;
+    width: 10px;
+    height: 10px;
+  }
+  &::-webkit-scrollbar-button {
+    width: 0px;
+    height: 0px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-clip: content-box;
+    background-color: ${renderThemeIfPresentOrDefault({ key: 'white40', defaultValue: colors.black40 })};
+    border: 1px solid transparent;
+    border-radius: 5px;
+  }
+  &::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  box-shadow: ${(props) => {
+    if (props.theme.optionsListShadow) return props.theme.optionsListShadow;
+    return boxShadows.lvl8;
+  }};
+
+  animation: ${fadeIn} 0.5s cubic-bezier(0, 0.55, 0.45, 1) 1;
+  transform-origin: top left;
+`;
+
+const Spacer = styled.div`
+  height: 0;
+  width: 100%;
+  border-bottom: 1px solid
+    ${(props) => renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: colors.white40 })};
+  margin: 8px 0 8px 0;
+`;
+
+function renderOptions({
+  focusedOption,
+  isMultiSelect,
+  onSearch,
+  onSearchClick,
+  onSelect,
+  options,
+  selectLabel,
+  selectedOptions,
+}) {
+  const combinedOptions = options.options.map((option, index) => {
+    if (option.type === 'search') {
+      return (
+        <Search
+          key={`select-${selectLabel}__search-${index}`}
+          isFocused={option.focusIndex === focusedOption}
+          onSearch={onSearch}
+          onClick={onSearchClick}
+          empty={options.options.length === 1}
+        />
+      );
+    }
+    if (option.type === 'option') {
+      if (!option || !option.option) return null;
+      const isSelected = _.some(selectedOptions, (selectedOption) => selectedOption === option.option.value);
+      return (
+        <Option
+          key={`select-${selectLabel}__${option.option.value}-${index}`}
+          onClick={(o) => onSelect(o, option.focusIndex)}
+          option={option.option}
+          isFocused={option.focusIndex === focusedOption}
+          isMultiSelect={isMultiSelect}
+          isSelected={isMultiSelect && isSelected}
+        />
+      );
+    }
+    if (option.type === 'divider') return <Spacer key={`select-${selectLabel}__spacer-${index}`} />;
+    return null;
+  });
+  return combinedOptions;
+}
+class Dropdown extends React.Component {
+  render() {
+    return (
+      <Options optionsWidth={this.props.optionsWidth} isOpen={this.props.isOpen}>
+        {renderOptions({
+          focusedOption: this.props.focusedOption,
+          isMultiSelect: this.props.isMultiSelect,
+          onSearch: this.props.onSearch,
+          onSearchClick: this.props.onSearchClick,
+          onSelect: this.props.onSelect,
+          options: this.props.options,
+          selectLabel: this.props.selectLabel,
+          selectedOptions: this.props.selectedOptions,
+        })}
+      </Options>
+    );
+  }
+}
+
+Dropdown.defaultProps = {
+  focusedOption: 0,
+  onSelect: _.noop,
+  onSearch: _.noop,
+  onSearchClick: _.noop,
+  isOpen: false,
+  isMultiSelect: false,
+};
+
+Dropdown.propTypes = {
+  focusedOption: PropTypes.number,
+  isMultiSelect: PropTypes.bool,
+  isOpen: PropTypes.bool.isRequired,
+  onSearch: PropTypes.func,
+  onSearchClick: PropTypes.func,
+  onSelect: PropTypes.func,
+  options: PropTypes.any.isRequired,
+  optionsWidth: PropTypes.string,
+  selectLabel: PropTypes.string,
+  selectedOptions: PropTypes.any,
+};
+
+export default Dropdown;

--- a/src/components/SelectInputKeyboard/Label.js
+++ b/src/components/SelectInputKeyboard/Label.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { typography, colors, renderThemeKeyOrDefaultValue } from '../styles';
+
+const Wrapper = styled.label`
+  transition: all 200ms;
+  transform: translateY(-50%);
+  position: absolute;
+  left: 16px;
+  top: ${(props) => (props.isOptionSelected ? '30%' : '50%')};
+  ${labelColor}
+  ${(props) => props.isOptionSelected && typography.caption}
+`;
+
+function labelColor(props) {
+  if (props.isDisabled)
+    return `color: ${renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: colors.white40 })};`;
+  if (props.error)
+    return `color: ${renderThemeKeyOrDefaultValue({ props, key: 'warning04', defaultValue: colors.red })};`;
+  return `color: ${renderThemeKeyOrDefaultValue({ props, key: 'white90', defaultValue: colors.white90 })};`;
+}
+
+function Label({ error, isDisabled, isOptionSelected, label }) {
+  return (
+    <Wrapper error={error} isDisabled={isDisabled} isOptionSelected={isOptionSelected}>
+      {this.props.label}
+    </Wrapper>
+  );
+}
+
+Label.propTypes = {
+  error: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  isOptionSelected: PropTypes.bool.isRequired,
+  label: PropTypes.any,
+};
+
+export default Label;

--- a/src/components/SelectInputKeyboard/Option.js
+++ b/src/components/SelectInputKeyboard/Option.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { keyframes } from 'styled-components';
+import { renderThemeKeyOrDefaultValue } from '../styles';
+
+import Checkbox from '../Checkbox';
+
+const fadeIn = keyframes`
+  0% { opacity: 0; }
+  10% { opacity: 0; }
+  60% { opacity: 1; }
+`;
+
+const ListItem = styled.li`
+  display: flex;
+  align-items: center;
+  color: ${(props) => renderThemeKeyOrDefaultValue({ props, key: 'white90', defaultValue: props.theme.white90 })};
+  padding: 0 24px;
+  line-height: 36px;
+  cursor: pointer;
+  background: ${optionBackground};
+  ${(props) => (props.bottomBorder ? 'border-bottom: 1px solid white' : '')}
+
+  &:hover {
+    background: ${optionHoverBackground};
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  animation: ${fadeIn} 0.5s ease-out 1;
+  transform-origin: top left;
+`;
+
+function optionBackground(props) {
+  if (props.isFocused) {
+    return renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: props.theme.background });
+  }
+}
+
+function optionHoverBackground(props) {
+  if (props.isFocused) {
+    return renderThemeKeyOrDefaultValue({ props, key: 'white60', defaultValue: props.theme.background });
+  }
+  return renderThemeKeyOrDefaultValue({ props, key: 'white10', defaultValue: props.theme.background });
+}
+
+class Option extends React.Component {
+  componentDidUpdate() {
+    if (this.props.isFocused) this.element.scrollIntoViewIfNeeded();
+    if (this.props.isFocused) this.element.focus();
+  }
+
+  render() {
+    return (
+      <ListItem
+        tabIndex={-1}
+        onClick={(event) => {
+          this.element.focus();
+          this.props.onClick(this.props.option);
+        }}
+        isFocused={this.props.isFocused}
+        innerRef={(element) => (this.element = element)}
+        bottomBorder={this.props.isPromoted}
+      >
+        {this.props.isMultiSelect && <Checkbox tabIndex={-1} disabled={false} checked={this.props.isSelected} />}
+        {this.props.option.label}
+      </ListItem>
+    );
+  }
+}
+
+Option.propTypes = {
+  isFocused: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+  option: PropTypes.object.isRequired,
+  isSelected: PropTypes.bool,
+  isMultiSelect: PropTypes.bool,
+  isPromoted: PropTypes.bool,
+};
+
+export default Option;

--- a/src/components/SelectInputKeyboard/Search.js
+++ b/src/components/SelectInputKeyboard/Search.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { renderThemeKeyOrDefaultValue, typography, colors } from '../styles';
+import TextInput, { TextBox } from '../TextInput';
+import _ from 'lodash';
+
+const StyledSearchInput = styled(TextInput)`
+  ${TextBox} {
+    'background-color: transparent;'
+  }
+`;
+
+const SearchWrapper = styled.div`
+  padding: 0 24px 12px 24px;
+  outline: none;
+`;
+
+const SearchEmptyText = styled.div`
+  padding-top: 12px;
+  color: ${(props) => renderThemeKeyOrDefaultValue({ props, key: 'white60', defaultValue: colors.white60 })};
+  ${typography.subhead1}
+`;
+
+class Search extends React.Component {
+  componentDidUpdate() {
+    if (this.props.isFocused) this.element.scrollIntoViewIfNeeded();
+    if (this.props.isFocused) this.element.querySelector('input').focus();
+  }
+
+  render() {
+    return (
+      <SearchWrapper
+        tabIndex={-1}
+        isFocused={this.props.isFocused}
+        innerRef={(element) => (this.element = element)}
+        onClick={this.props.onClick}
+      >
+        <StyledSearchInput tabIndex={-1} label="Search" name="selectSearch" onChange={this.props.onSearch} search />
+        {this.props.empty && <SearchEmptyText>No options match that search criteria</SearchEmptyText>}
+      </SearchWrapper>
+    );
+  }
+}
+
+Search.defaultProps = {
+  isFocused: false,
+  onClick: _.noop,
+  onSearch: _.noop,
+};
+
+Search.propTypes = {
+  isFocused: PropTypes.bool,
+  onClick: PropTypes.func,
+  onSearch: PropTypes.func,
+};
+
+export default Search;

--- a/src/components/SelectInputKeyboard/SelectInputKeyboard.js
+++ b/src/components/SelectInputKeyboard/SelectInputKeyboard.js
@@ -1,0 +1,484 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { ThemeProvider } from 'styled-components';
+import _ from 'lodash';
+import { RequiredText } from '../RequiredText/RequiredText';
+import { typography, colors, renderThemeKeyOrDefaultValue } from '../styles';
+
+import Dropdown from './Dropdown';
+import Label from './Label';
+import Caret from './Caret';
+
+const regexp = {
+  singleCharacter: /^([^\x00-\x7F]|[^\u0000-\u007F]|[\w-_]){1}$/,
+  whitespace: /\s/g,
+};
+
+const Wrapper = styled.div`
+  position: relative;
+  outline: none;
+  user-select: none;
+`;
+
+const SelectedLabel = styled.span`
+  padding: 22px 26px 0 16px;
+  color: ${(props) => {
+    if (props.isDisabled) return renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: colors.white40 });
+    if (props.error) return renderThemeKeyOrDefaultValue({ props, key: 'warning04', defaultValue: colors.red });
+    return renderThemeKeyOrDefaultValue({ props, key: 'white90', defaultValue: colors.white90 });
+  }};
+`;
+
+const SelectToggle = styled.div`
+  position: relative;
+  display: flex;
+  align-items: normal;
+  outline: none;
+  width: 100%;
+  height: 56px;
+  padding: 0;
+  text-align: left;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  border: 0;
+  border-bottom-width: 2px;
+  border-bottom-style: solid;
+  border-radius: 2px;
+  border-bottom-color: ${(props) => {
+    if (props.isDisabled) {
+      return 'transparent';
+    }
+    if (props.error && props.isFocused) {
+      return renderThemeKeyOrDefaultValue({ props, key: 'warning01', defaultValue: colors.black40 });
+    }
+    if (props.error) {
+      return renderThemeKeyOrDefaultValue({ props, key: 'warning04', defaultValue: colors.red });
+    }
+    if (props.isFocused) {
+      return renderThemeKeyOrDefaultValue({ props, key: 'brand01', defaultValue: colors.black40 });
+    }
+    if (props.theme.borderColor) {
+      return renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: props.theme.borderColor });
+    }
+    return renderThemeKeyOrDefaultValue({ props, key: 'white40', defaultValue: colors.black40 });
+  }};
+
+  cursor: ${(props) => (props.isDisabled ? 'auto' : 'pointer')};
+
+  color: ${(props) => renderThemeKeyOrDefaultValue({ props, key: 'white60', defaultValue: colors.black60 })};
+  background: ${(props) =>
+    renderThemeKeyOrDefaultValue({ props, key: 'primary05', defaultValue: props.theme.background })};
+
+  ${typography.subhead1};
+`;
+
+function focusNextOption({ focusedOption, optionsLength }) {
+  if (typeof focusedOption !== 'number') return 0;
+  return focusedOption >= optionsLength - 1 ? 0 : focusedOption + 1;
+}
+
+function focusPreviousOption({ focusedOption, optionsLength }) {
+  if (typeof focusedOption !== 'number') return optionsLength - 1;
+  return focusedOption <= 0 ? optionsLength - 1 : focusedOption - 1;
+}
+
+function handleButtonClick(setState) {
+  return function () {
+    setState((prevState) => ({
+      isOpen: !prevState.isOpen,
+    }));
+  };
+}
+
+function handleBlur(event) {
+  this.timeoutID = setTimeout(() => {
+    if (this.state.isFocused) {
+      this.setState({
+        isFocused: false,
+        isOpen: false,
+      });
+    }
+  }, 0);
+}
+
+function handleFocus(event) {
+  clearTimeout(this.timeoutID);
+  if (!this.state.isFocused) {
+    this.setState({
+      isFocused: true,
+    });
+  }
+}
+
+function getFocusedOptionValue({ options, focusedOption }) {
+  const option = _.find(options.options, { focusIndex: focusedOption });
+  if (!option || !option.option) return null;
+  return option.option;
+}
+
+const validOpeningKeys = ['Enter', ' ', 'ArrowDown', 'ArrowUp'];
+
+function focusableOptions({ options }) {
+  return options.filter(option => {
+    return _.isNumber(option.focusIndex);
+  });
+}
+
+function handleKeyDown({
+  currentOption,
+  focusedOption,
+  isMultiSelect,
+  isOpen,
+  onChange,
+  options,
+  searchable,
+  setState,
+  setStateDebounced,
+  wrapperElement,
+}) {
+  return function (event) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      wrapperElement.focus();
+      setState({
+        isOpen: false,
+      });
+      return;
+    }
+
+    if (!isOpen && _.some(validOpeningKeys, (key) => key === event.key)) {
+      setState({ isOpen: true });
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleOptionSelected({
+        currentOption: currentOption,
+        isMultiSelect: isMultiSelect,
+        onChangeFunction: onChange,
+        setState: setState,
+        wrapperElement: wrapperElement,
+      })(getFocusedOptionValue({ options, focusedOption }), focusedOption);
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setState({
+        isOpen: true,
+        focusedOption: focusNextOption({
+          focusedOption: focusedOption,
+          optionsLength: focusableOptions({options: options.options}).length,
+        }),
+      });
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setState({
+        isOpen: true,
+        focusedOption: focusPreviousOption({
+          focusedOption: focusedOption,
+          optionsLength: focusableOptions({options: options.options}).length,
+        }),
+      });
+      return;
+    }
+
+    const isKeyModifierActive = event.altKey || event.ctrlKey || event.metaKey;
+    if (
+      !isKeyModifierActive &&
+      isOpen &&
+      !(searchable && focusedOption === 0) &&
+      event.key.match(regexp.singleCharacter)
+    ) {
+      const key = event.key;
+      event.preventDefault();
+      setState((prevState) => {
+        const softSearchFilter = `${prevState.softSearchFilter}${key.toLowerCase()}`;
+        const beginsWithSoftSearch = new RegExp('^' + softSearchFilter);
+        const newFocusedOption = _.find(options.options, (option) => {
+          if (!option.option) return false;
+          if (!_.isString(option.option.label)) return false;
+          if (beginsWithSoftSearch.test(option.option.label.toLowerCase().replace(regexp.whitespace, ''))) return true;
+          return false;
+        });
+        return {
+          softSearchFilter,
+          focusedOption:
+            newFocusedOption && _.isNumber(newFocusedOption.focusIndex)
+              ? newFocusedOption.focusIndex
+              : prevState.focusedOption,
+        };
+      });
+      setStateDebounced({ softSearchFilter: '' });
+      return;
+    }
+  };
+}
+
+function handleOptionSelected({ currentOption, isMultiSelect, onChangeFunction, setState, wrapperElement }) {
+  return function (option, focusIndex) {
+    if (!_.isObject(option)) return;
+    wrapperElement.focus();
+    setState({
+      isOpen: !!isMultiSelect,
+      focusedOption: focusIndex,
+    });
+
+    if (isMultiSelect) {
+      if (!Array.isArray(currentOption)) {
+        onChangeFunction([option.value]);
+      } else if (currentOption.includes(option.value)) {
+        onChangeFunction(_.without(currentOption, option.value));
+      } else {
+        onChangeFunction([...currentOption, option.value]);
+      }
+    } else {
+      onChangeFunction(option.value);
+    }
+  };
+}
+
+function handleSearch({ setState }) {
+  return function (searchFilter) {
+    setState({ searchFilter });
+  };
+}
+
+function handleSearchClick({ setState }) {
+  return function (_event) {
+    setState({ focusedOption: 0 });
+  };
+}
+
+function isValued(value) {
+  if (value === undefined || value === null) return false;
+  else if (typeof value === 'boolean') return true;
+  else if (typeof value === 'number') return true;
+  else if (typeof value === 'string' && value.length > 0) return true;
+  else if (Array.isArray(value) && value.length > 0) return true;
+  else if (typeof value === 'symbol') return true;
+
+  return typeof value === 'object' && Object.keys(value).length > 0;
+}
+
+function SelectedOption({ selectedOptions, options, error, isDisabled }) {
+  return (
+    <SelectedLabel error={error} isDisabled={isDisabled}>
+      {getLabel({ selectedOptions, options })}
+    </SelectedLabel>
+  );
+}
+
+function getLabel({ selectedOptions, options }) {
+  if (Array.isArray(selectedOptions) && selectedOptions.length > 0) {
+    return `${selectedOptions.length} Selected`;
+  }
+  return options.reduce((label, option) => {
+    if (selectedOptions === option.value) return option.label;
+    return label;
+  }, selectedOptions);
+}
+
+function filterOptionsWithSearch({ options, searchFilter = '' }) {
+  if (!_.isArray(options) || _.isEmpty(options)) return [];
+  return options.filter((option) => {
+    if (!_.isObject(option)) return true;
+    if (!(_.isString(option.label) || _.isObject(option.label))) return true;
+    if (_.isObject(option.label) && !_.isString(option.optionValue)) return true;
+
+    const labelString = _.isString(option.label) ? option.label : option.optionValue;
+    return _.includes(labelString.toLowerCase(), searchFilter.toLowerCase());
+  });
+}
+
+function prepareOptions({ promotedOptions, options, searchable }) {
+  let focusCount = 0;
+
+  const searchInput = searchable
+    ? [
+        {
+          type: 'search',
+          focusIndex: focusCount++,
+        },
+      ]
+    : [];
+
+  const divider = { type: 'divider' };
+  const preparedPromotedOptions = _.isEmpty(promotedOptions)
+    ? []
+    : [
+        ...promotedOptions.map((option) => {
+          return {
+            type: 'option',
+            focusIndex: focusCount++,
+            option,
+          };
+        }),
+        divider,
+      ];
+
+  const preparedOptions = options.map((option) => {
+    return {
+      type: 'option',
+      focusIndex: focusCount++,
+      option,
+    };
+  });
+
+  const newOptions = [...searchInput, ...preparedPromotedOptions, ...preparedOptions];
+  return {
+    options: newOptions,
+  };
+}
+
+export default class SelectInputKeyboard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isFocused: false,
+      isOpen: false,
+      focusedOption: 0,
+      searchFilter: '',
+      softSearchFilter: '',
+    };
+    this.setState = this.setState.bind(this);
+    this.setStateDebounced = _.debounce(this.setState, 1000).bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // If options props are updated, reset focused state
+    if (nextProps.options !== this.props.options || nextProps.promotedOptions !== this.props.promotedOptions) {
+      this.setState({
+        isOpen: false,
+        focusedOption: 0,
+      });
+    }
+    // If search prop is updated, reset search filter
+    if (nextProps.searchable !== this.props.searchable) {
+      this.setState({
+        searchFilter: '',
+      });
+    }
+  }
+
+  render() {
+    const options = filterOptionsWithSearch({
+      options: this.props.options,
+      searchFilter: this.state.searchFilter,
+    });
+    const promotedOptions = filterOptionsWithSearch({
+      options: this.props.promotedOptions,
+      searchFilter: this.state.searchFilter,
+    });
+
+    const preparedOptions = prepareOptions({ promotedOptions, options, searchable: this.props.searchable });
+
+    return (
+      <ThemeProvider theme={this.props.theme}>
+        <Wrapper
+          className={this.props.className}
+          innerRef={(wrapperElement) => (this.wrapperElement = wrapperElement)}
+          onBlur={handleBlur.bind(this)}
+          onFocus={handleFocus.bind(this)}
+          onKeyDown={
+            !this.props.isDisabled &&
+            handleKeyDown({
+              currentOption: this.props.value,
+              focusedOption: this.state.focusedOption,
+              isMultiSelect: this.props.multiSelect,
+              isOpen: this.state.isOpen,
+              onChange: this.props.onChange,
+              options: preparedOptions,
+              searchable: this.props.searchable,
+              setState: this.setState,
+              setStateDebounced: this.setStateDebounced,
+              wrapperElement: this.wrapperElement,
+            })
+          }
+          tabIndex={this.props.isDisabled ? -1 : 0}
+        >
+          <SelectToggle
+            error={this.props.error}
+            isDisabled={this.props.isDisabled}
+            isFocused={this.state.isFocused}
+            onClick={!this.props.isDisabled && handleButtonClick(this.setState)}
+            tabIndex={-1}
+          >
+            <Label
+              error={this.props.error}
+              isDisabled={this.props.isDisabled}
+              isOptionSelected={isValued(this.props.value)}
+              label={this.props.label}
+            />
+            <Caret error={this.props.error} isDisabled={this.props.isDisabled} isOpen={this.state.isOpen} />
+            {!this.props.value && !this.state.isOpen && this.props.required && (
+              <RequiredText error={this.props.error}>Required</RequiredText>
+            )}
+            <SelectedOption
+              error={this.props.error}
+              isDisabled={this.props.isDisabled}
+              isMultiSelect={this.props.multiSelect}
+              options={[...(this.props.promotedOptions || []), ...this.props.options]}
+              selectedOptions={this.props.value}
+            />
+          </SelectToggle>
+          <Dropdown
+            focusedOption={this.state.focusedOption}
+            selectLabel={this.props.label}
+            isMultiSelect={this.props.multiSelect}
+            isOpen={this.state.isOpen}
+            onSearch={handleSearch({ setState: this.setState })}
+            onSearchClick={handleSearchClick({ setState: this.setState })}
+            onSelect={handleOptionSelected({
+              currentOption: this.props.value,
+              isMultiSelect: this.props.multiSelect,
+              onChangeFunction: this.props.onChange,
+              setState: this.setState,
+              wrapperElement: this.wrapperElement,
+            })}
+            options={preparedOptions}
+            optionsWidth={this.props.optionsWidth}
+            searchable={this.props.searchable}
+            selectedOptions={this.props.value}
+          />
+        </Wrapper>
+      </ThemeProvider>
+    );
+  }
+}
+
+SelectInputKeyboard.defaultProps = {
+  error: false,
+  isDisabled: false,
+  isPlaceHolder: false,
+  label: '',
+  multiSelect: false,
+  onChange: _.noop,
+  options: [],
+  promotedOptions: [],
+  required: false,
+  theme: {},
+  value: '',
+};
+
+SelectInputKeyboard.propTypes = {
+  error: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  isPlaceHolder: PropTypes.bool,
+  label: PropTypes.string,
+  multiSelect: PropTypes.bool,
+  onChange: PropTypes.func,
+  options: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.any, label: PropTypes.any })).isRequired,
+  optionsWidth: PropTypes.number,
+  promotedOptions: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.any, label: PropTypes.any })),
+  required: PropTypes.bool,
+  searchable: PropTypes.bool,
+  value: PropTypes.any,
+};

--- a/src/components/SelectInputKeyboard/SelectInputKeyboard.stories.js
+++ b/src/components/SelectInputKeyboard/SelectInputKeyboard.stories.js
@@ -1,0 +1,179 @@
+import React from 'react';
+import { storiesOf, action } from '@storybook/react';
+import SelectInputKeyboard from './SelectInputKeyboard';
+import SelectInputLabelBox from '../SelectInputLabelBox';
+import Button from '../Button';
+import styled from 'styled-components';
+
+import { renderThemeIfPresentOrDefault, wrapComponentWithContainerAndTheme, colors, typography } from '../styles';
+
+const OptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-top: 6px;
+  padding-bottom: 6px;
+`;
+
+const StyledButton = styled(Button)`
+  height: 24px;
+  padding: 0 4px;
+  span {
+    font-size: 10px;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  button {
+    margin-right: 4px;
+  }
+`;
+
+const OptionLabel = styled.div`
+  ${typography.caption};
+  color: ${renderThemeIfPresentOrDefault({
+    key: 'white60',
+    defaultValue: colors.black60,
+  })};
+`;
+
+const OptionValue = styled.div`
+  ${typography.subhead1};
+  color: ${renderThemeIfPresentOrDefault({
+    key: 'white90',
+    defaultValue: colors.black90,
+  })};
+`;
+
+const promotedOption = [
+  { value: 'p1', label: 'Promoted Option 1' },
+  { value: 'p2', label: 'Promoted Option 2' },
+  { value: 'p3', label: 'Promoted Option 3' },
+];
+
+const genericOptions = [
+  { value: '1', label: 'Option One' },
+  { value: '2', label: 'Option Two' },
+  { value: '3', label: 'Option Three' },
+  { value: '4', label: 'Option Four' },
+  { value: '5', label: 'Option Five' },
+  { value: '6', label: 'Option Six' },
+  { value: '7', label: 'Option Seven' },
+  { value: '8', label: 'Option Eight' },
+  { value: '9', label: 'Option Nine' },
+  { value: '10', label: 'Option Ten' },
+  {
+    value: '11',
+    label:
+      'A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string A really long string',
+  },
+  { value: 12, label: `I'm a number` },
+  {
+    value: '13',
+    label: (
+      <OptionWrapper>
+        <OptionLabel>HTML Label</OptionLabel>
+        <OptionValue>option 13</OptionValue>
+      </OptionWrapper>
+    ),
+    optionLabel: 'option 13 label',
+    optionValue: 'option 13',
+  },
+  { value: true, label: 'True' },
+  { value: false, label: 'False' },
+];
+
+class WrapperComponent extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      value: '',
+    };
+  }
+
+  toggle = (param) => {
+    this.setState((prevState) => ({
+      [param]: !prevState[param],
+    }));
+  };
+
+  toggleValue = (param, value) => {
+    this.setState((prevState) => ({
+      [param]: prevState[param] === value ? null : value,
+    }));
+  };
+
+  handleSelectInputChange = (value) => {
+    action('Option Selected')(value);
+    this.setState({ value });
+  };
+
+  render = () => (
+    <div>
+      <ButtonWrapper>
+        <StyledButton flat label="Clear Value" onClick={() => this.setState({ value: '' })} />
+        <StyledButton flat={!this.state.error} label="error" onClick={() => this.toggle('error')} />
+        <StyledButton flat={!this.state.isDisabled} label="isDisabled" onClick={() => this.toggle('isDisabled')} />
+        <StyledButton flat={!this.state.required} label="required" onClick={() => this.toggle('required')} />
+        <StyledButton flat={!this.state.searchable} label="searchable" onClick={() => this.toggle('searchable')} />
+        <StyledButton flat={!this.state.multiSelect} label="multiSelect" onClick={() => this.toggle('multiSelect')} />
+        <StyledButton
+          flat={!this.state.optionsWidth}
+          label="optionsWidth"
+          onClick={() => this.toggleValue('optionsWidth', '240')}
+        />
+        <StyledButton
+          flat={!this.state.promotedOptions}
+          label="promotedOptions"
+          onClick={() => this.toggleValue('promotedOptions', promotedOption)}
+        />
+      </ButtonWrapper>
+      {this.props.old ? (
+        <SelectInputLabelBox {...this.props} {...this.state} onChange={this.handleSelectInputChange} />
+      ) : (
+        <SelectInputKeyboard {...this.props} {...this.state} onChange={this.handleSelectInputChange} />
+      )}
+    </div>
+  );
+}
+
+function renderChapterWithTheme(theme) {
+  return {
+    info: `
+      Usage
+
+      ~~~
+      import React from 'react';
+      import {Select} from 'insidesales-components';
+      ~~~
+    `,
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'New Select',
+            options: {
+              showSource: false,
+            },
+            sectionFn: () =>
+              wrapComponentWithContainerAndTheme(
+                theme,
+                <div>
+                  <WrapperComponent label="Input Label" options={genericOptions} />
+                </div>,
+              ),
+          }
+        ],
+      },
+    ],
+  };
+}
+
+storiesOf('Form', module)
+  .addWithChapters('Default SelectInputKeyboard', renderChapterWithTheme({}))
+  .addWithChapters('SelectInputKeyboard w/ BlueYellow Theme', renderChapterWithTheme(colors.blueYellowTheme));

--- a/src/components/SelectInputKeyboard/SelectInputKeyboardThemes.js
+++ b/src/components/SelectInputKeyboard/SelectInputKeyboardThemes.js
@@ -1,0 +1,21 @@
+import { darkBlue, white } from '../styles/colors';
+
+export const lineSelectInputKeyboardTransparentTheme = {
+  background: 'transparent',
+  borderRadius: '0',
+  borderWidth: '1px',
+  leftDisplayPosition: '0',
+  caretTopPosition: '62%',
+  optionListPositionLeft: '0',
+  selectDisplayWidth: '240px',
+};
+
+export const darkTheme = {
+  background: darkBlue.darkBlue,
+  valueColor: white.white90,
+  labelColor: white.white60,
+  borderColor: white.white40,
+  requiredColor: white.white60,
+};
+
+export default { lineSelectInputKeyboardTransparentTheme, darkTheme };

--- a/src/components/SelectInputKeyboard/index.js
+++ b/src/components/SelectInputKeyboard/index.js
@@ -1,0 +1,3 @@
+export { default } from './SelectInputKeyboard';
+
+export { default as SelectInputKeyboardThemes } from './SelectInputKeyboardThemes';

--- a/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
+++ b/src/components/SelectInputLabelBox/SelectInputLabelBox.stories.js
@@ -10,7 +10,7 @@ import {
   colors,
   typography
 } from "../styles";
-import { SelectInputLabelBoxThemes } from "../index";
+import { SelectInputLabelBoxThemes } from "./index";
 
 const OptionWrapper = styled.div`
   display: flex;

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -126,7 +126,7 @@ export const InputItem = styled.input`
   text-align: left;
   width: 100%;
   color: ${colors.renderThemeIfPresentOrDefault({key: 'white90', defaultValue: colors.black90 })};
-  
+
   &:focus {
     outline: 0;
   }
@@ -395,7 +395,8 @@ class TextInput extends React.Component {
       labelColor,
       lineColor,
       outlinedSearch,
-      autoFocus
+      autoFocus,
+      tabIndex
     } = this.props;
 
     return (
@@ -429,6 +430,7 @@ class TextInput extends React.Component {
             search={this.props.search}
             placeholder={this.usePlaceholder()}
             autoFocus={autoFocus}
+            tabIndex={tabIndex}
             className="pb-test__text-input" />
           {this.props.search &&
             <SearchIcon fill={colors.dustyGray} size={{ width: 22, height: 22 }} />
@@ -463,6 +465,7 @@ TextInput.defaultProps = {
   label: DEFAULT_LABEL,
   onSelectionStartChange: _.noop,
   stateless: false,
+  tabIndex: 0
 };
 
 TextInput.propTypes = {
@@ -489,7 +492,8 @@ TextInput.propTypes = {
     value: PropTypes.any,
     label: PropTypes.string,
     disabled: PropTypes.bool
-  }))
+  })),
+  tabIndex: PropTypes.number
 };
 
 export default TextInput;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -41,8 +41,11 @@ export {default as Icons} from './icons';
 export {default as RadioList} from './RadioList';
 export {default as Radio} from './RadioList/Radio';
 export {
-  default as SelectInputLabelBox,
-  SelectInputLabelBoxThemes
+  default as SelectInputKeyboard,
+  SelectThemes
+} from './SelectInputKeyboard';
+export {
+  default as SelectInputLabelBox
 } from './SelectInputLabelBox';
 export {default as TextareaBox} from './TextareaBox';
 export {


### PR DESCRIPTION
Regarding what we talked about in the video review:

**Fix binding of this in onBlur and onFocus functions**
The way this hack is working relies on setting a class variable instead of state so that it can clear the blur event if it happens in the same tick as the focus. There's probably a better way to do this, but I haven't found an alternative method yet.

**Add escape key functionality**
I added this. It now will close the menu but maintain focus of the select element upon hitting escape.

**Deselect button**
Design is out of office at the moment. I'm going to say that this is OK to publish without that button for now, since the `SelectInputLabelBox` component is also missing this button. I'll make a separate issue to make sure this is addressed in the future.
