### PR TITLE
fix(SelectInputLabelBox): Restore theme export for SelectInputLabelBox

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -42,10 +42,11 @@ export {default as RadioList} from './RadioList';
 export {default as Radio} from './RadioList/Radio';
 export {
   default as SelectInputKeyboard,
-  SelectThemes
+  SelectInputKeyboardThemes
 } from './SelectInputKeyboard';
 export {
-  default as SelectInputLabelBox
+  default as SelectInputLabelBox,
+  SelectInputLabelBoxThemes
 } from './SelectInputLabelBox';
 export {default as TextareaBox} from './TextareaBox';
 export {


### PR DESCRIPTION
The changes I made for the select input keyboard functionality broke the way the themes were exported for both select label box components. This restores it.